### PR TITLE
NEW: Empty link title fallbacks to Page.

### DIFF
--- a/src/Models/SiteTreeLink.php
+++ b/src/Models/SiteTreeLink.php
@@ -30,6 +30,7 @@ class SiteTreeLink extends Link
             return '';
         }
 
+        /** @var SiteTree $page */
         $page = SiteTree::get()->byID($data['PageID']);
 
         return $page ? $page->URLSegment : '';
@@ -58,12 +59,26 @@ class SiteTreeLink extends Link
         return $fields;
     }
 
-    public function getURL()
+    public function getURL(): ?string
     {
         $url = $this->Page ? $this->Page->Link() : '';
+
         if ($this->Anchor) {
             $url .= '#' . $this->Anchor;
         }
+
         return $url;
+    }
+
+    public function onBeforeWrite(): void
+    {
+        parent::onBeforeWrite();
+
+        if ($this->Title || !$this->Page->exists()) {
+            return;
+        }
+
+        // Use page title as a default value in case CMS user didn't provide the title
+        $this->Title = $this->Page->Title;
     }
 }

--- a/src/Models/SiteTreeLink.php
+++ b/src/Models/SiteTreeLink.php
@@ -7,7 +7,8 @@ use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Forms\TreeDropdownField;
 
 /**
- * A link to a Page in the CMS.
+ * A link to a Page in the CMS
+ *
  * @property SiteTree $Page
  * @property int $PageID
  * @property string $Anchor
@@ -74,11 +75,36 @@ class SiteTreeLink extends Link
     {
         parent::onBeforeWrite();
 
-        if ($this->Title || !$this->Page->exists()) {
-            return;
+        $this->populateTitle();
+    }
+
+    protected function populateTitle(): void
+    {
+        $title = $this->getTitleFromPage();
+        $this->extend('updateGetTitleFromPage', $title);
+        $this->Title = $title;
+    }
+
+    /**
+     * Try to populate link title from page title in case we don't have a title yet
+     *
+     * @return string|null
+     */
+    protected function getTitleFromPage(): ?string
+    {
+        if ($this->Title) {
+            // If we already have a title, we can just bail out without any changes
+            return $this->Title;
+        }
+
+        $page = $this->Page;
+
+        if (!$page || !$page->exists()) {
+            // We don't have a page to fall back to
+            return null;
         }
 
         // Use page title as a default value in case CMS user didn't provide the title
-        $this->Title = $this->Page->Title;
+        return $this->Page->Title;
     }
 }

--- a/tests/php/LinkModelTest.php
+++ b/tests/php/LinkModelTest.php
@@ -2,8 +2,11 @@
 
 namespace SilverStripe\Link\Tests;
 
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Link\Models\Link;
+use SilverStripe\Link\Models\SiteTreeLink;
+use SilverStripe\ORM\ValidationException;
 
 class LinkModelTest extends SapphireTest
 {
@@ -17,5 +20,31 @@ class LinkModelTest extends SapphireTest
         $model = $this->objFromFixture(Link::class, 'link-1');
 
         $this->assertEquals('FormBuilderModal', $model->LinkTypeHandlerName());
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    public function testSiteTreeLinkTitleFallback(): void
+    {
+        /** @var SiteTreeLink $model */
+        $model = $this->objFromFixture(SiteTreeLink::class, 'page-link-1');
+
+        $this->assertEquals('PageLink1', $model->Title, 'We expect to get a default Link title');
+
+        /** @var SiteTree $page */
+        $page = $this->objFromFixture(SiteTree::class, 'page-1');
+
+        $model->PageID = $page->ID;
+        $model->Title = '';
+        $model->write();
+
+        $this->assertEquals($page->Title, $model->Title, 'We expect to get the linked Page title');
+
+        $customTitle = 'My custom title';
+        $model->Title = $customTitle;
+        $model->write();
+
+        $this->assertEquals($customTitle, $model->Title, 'We expect to get the custom title not page title');
     }
 }

--- a/tests/php/LinkModelTest.yml
+++ b/tests/php/LinkModelTest.yml
@@ -1,3 +1,11 @@
 SilverStripe\Link\Models\Link:
   link-1:
     Title: Link1
+
+SilverStripe\Link\Models\SiteTreeLink:
+  page-link-1:
+    Title: PageLink1
+
+SilverStripe\CMS\Model\SiteTree:
+  page-1:
+    Title: Page1


### PR DESCRIPTION
# NEW: Empty link title fallbacks to Page

Fixes https://github.com/silverstripe/silverstripe-linkfield/issues/34