### PR TITLE
BUG: Change link type in via a GridField edit form.

### DIFF
--- a/src/Models/EmailLink.php
+++ b/src/Models/EmailLink.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\LinkField\Models;
 
 use SilverStripe\Forms\EmailField;
+use SilverStripe\Forms\FieldList;
 
 /**
  * A link to an Email address.
@@ -24,7 +25,7 @@ class EmailLink extends Link
         return isset($data['Email']) ? $data['Email'] : '';
     }
 
-    public function getCMSFields()
+    public function getCMSFields(): FieldList
     {
         $fields = parent::getCMSFields();
 

--- a/src/Models/SiteTreeLink.php
+++ b/src/Models/SiteTreeLink.php
@@ -4,6 +4,7 @@ namespace SilverStripe\LinkField\Models;
 
 use SilverStripe\CMS\Forms\AnchorSelectorField;
 use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TreeDropdownField;
 
 /**
@@ -38,7 +39,7 @@ class SiteTreeLink extends Link
         return $page ? $page->URLSegment : '';
     }
 
-    public function getCMSFields()
+    public function getCMSFields(): FieldList
     {
         $fields = parent::getCMSFields();
 

--- a/tests/php/Models/LinkTest.php
+++ b/tests/php/Models/LinkTest.php
@@ -2,10 +2,15 @@
 
 namespace SilverStripe\LinkField\Tests\Models;
 
+use ReflectionException;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\LinkField\Models\EmailLink;
+use SilverStripe\LinkField\Models\ExternalLink;
+use SilverStripe\LinkField\Models\FileLink;
 use SilverStripe\LinkField\Models\Link;
 use SilverStripe\LinkField\Models\SiteTreeLink;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ValidationException;
 
 class LinkTest extends SapphireTest
@@ -46,5 +51,33 @@ class LinkTest extends SapphireTest
         $model->write();
 
         $this->assertEquals($customTitle, $model->Title, 'We expect to get the custom title not page title');
+    }
+
+    /**
+     * @param string $class
+     * @param bool $expected
+     * @throws ReflectionException
+     * @dataProvider linkTypeProvider
+     */
+    public function testLinkType(string $class, bool $expected): void
+    {
+        /** @var Link $model */
+        $model = DataObject::singleton($class);
+        $fields = $model->getCMSFields();
+        $linkTypeField = $fields->fieldByName('Root.Main.LinkType');
+        $expected
+            ? $this->assertNotNull($linkTypeField, 'We expect to a find link type field')
+            : $this->assertNull($linkTypeField, 'We do not expect to a find link type field');
+    }
+
+    public function linkTypeProvider(): array
+    {
+        return [
+            [EmailLink::class, false],
+            [ExternalLink::class, false],
+            [FileLink::class, false],
+            [SiteTreeLink::class, false],
+            [Link::class, true],
+        ];
     }
 }


### PR DESCRIPTION
# BUG: Change link type in via a GridField edit form.

The root cause of this issue is no React UI support for GridField. This change is a small patch which allows the GridField UI to change link type. New generic links have to have specific type as a mandatory field. This doesn't address the root cause but it makes the available UI more usable.

Fixes https://github.com/silverstripe/silverstripe-linkfield/issues/33