### PR TITLE
PHP 8.1: Suppress deprecation notice

### DIFF
--- a/src/Extensions/ModalController.php
+++ b/src/Extensions/ModalController.php
@@ -22,9 +22,9 @@ class ModalController extends Extension
         'editorAnchorLink/$ItemID' => 'editorAnchorLink', // Matches LeftAndMain::methodSchema args
     ];
 
-    private static $allowed_actions = array(
+    private static $allowed_actions = [
         'DynamicLink',
-    );
+    ];
 
     /**
      * Builds and returns the external link form

--- a/src/Models/Link.php
+++ b/src/Models/Link.php
@@ -187,6 +187,7 @@ class Link extends DataObject implements JsonData, Type
         return $jsonData;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $typeKey = Registry::singleton()->keyByClassName(static::class);


### PR DESCRIPTION
`JsonSerializable` has defined the return type of `:mixed` for the `jsonSerialize()` method. I don't think we can define this in our module until we support a minimum of PHP 8.1.