### PR TITLE
Add PhoneField. Add migration helpers from Linkable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,12 @@ class Page extends SiteTree
     }
 }
 ```
+
+## Migrating from Shae Dawson's Linkable module
+
+https://github.com/sheadawson/silverstripe-linkable
+
+Shae Dawson's Linkable module was a much loved, and much used module. It is, unfortunately, no longer maintained. We
+have provided some steps and tasks that we hope can be used to migrate your project from Linkable to LinkField.
+
+* [Migraiton docs](docs/en/linkable-migration.md)

--- a/_config/types.yml
+++ b/_config/types.yml
@@ -16,3 +16,6 @@ SilverStripe\LinkField\Type\Registry:
     email:
       classname: SilverStripe\LinkField\Models\EmailLink
       enabled: true
+    phone:
+      classname: SilverStripe\LinkField\Models\PhoneLink
+      enabled: true

--- a/docs/en/linkable-migration.md
+++ b/docs/en/linkable-migration.md
@@ -1,0 +1,115 @@
+# Instructions
+
+## Preamble
+
+This migration process covers shifting data from the `Linkable` tables to the appropriate `LinkField` tables.
+
+This does not cover usages of `EmbeddedObject` (at least, not at this time).
+
+**Versioned:** If you have `Versioned` `Linkable`, then the expectation is that you will also `Version` `LinkField`. If
+you have not `Versioned` `Linkable`, then the expectation is that you will **not** `Version` `LinkField`.
+
+## Install Silvesrtripe Linkfield
+
+Install the Silverstripe Linkfield module:
+
+```bash
+$ composer require silverstripe/linkfield 1.x-dev
+```
+
+Or if you would like the (experimental) GraphQL 4 version:
+
+```bash
+$ composer require silverstripe/linkfield 2.x-dev
+```
+
+Optionally, you can also remove the Linkable module (though, you might find it useful to keep around as a reference
+while you are upgrading your code).
+
+Do this step at whatever point makes sense to you.
+
+```bash
+$ composer remove sheadawson/silverstripe-linkable
+```
+
+## Replace app usages
+
+You should review how you are using the original `Link` model and `LinkField`, but if you don't have any customisations,
+then replacing the old with the new **might** be quite simple.
+
+If you have used imports (`use` statements), then your first step might just be to search for `use [old];` and replace
+with `use [new];` (since the class name references have not changed at all).
+
+Old: `Sheadawson\Linkable\Models\Link`
+New: `SilverStripe\LinkField\Models\Link`
+
+Old: `Sheadawson\Linkable\Forms\LinkField`
+New: `SilverStripe\LinkField\Form\LinkField`
+
+If you have extensions, new fields, etc, then your replacements might need to be a bit more considered.
+
+The other key (less easy to automate) thing that you'll need to update is that the old `LinkField` required you to
+specify the related field with `ID` appended, whereas the new `LinkField` requires you to specify the field without
+`ID` appended. EG.
+
+Old: `LinkField::create('MyLinkID')`
+New: `LinkField::create('MyLink')`
+
+Search for instances of `LinkField::create` and `new LinkField`, and hopefully that should give you all of the places
+where you need to update field name references.
+
+### Configuration
+
+Be sure to check how the old module classes are referenced in config `yml` files (eg: `app/_config`). Update
+appropriately.
+
+### Populate module
+
+If you use the populate module, you will not be able to simply "replace" the namespace. Fixture definitions for the
+new Linkfield module are quite different. There are entirely different models for different link types, whereas before
+it was just a DB field to specify the type.
+
+## Replace template usages
+
+Before: You might have had references to `$LinkURL` or `$Link.LinkURL`.
+After: These would need to be updated to `$URL` or `$Link.URL` respectively.
+
+Before: `$OpenInNewWindow` or `$Link.OpenInNewWindow`.
+After: `$OpenInNew` or `$Link.OpenInew` respectively.
+
+Before: `$Link.TargetAttr` or `$TargetAttr` would output the appropriate `target="xx"`.
+After: There is no direct replacement.
+
+This is an area where you should spend some decent effort to make sure each implementation is outputting as you expect
+it to. There may be more "handy" methods that Linkable provided that no longer exist (that we haven't covered above).
+
+## Table structures
+
+It's important to understand that we are going from a single table in Linkable to multiple tables in LinkField.
+
+**Before:** We had 1 table with all data, and one of the field in there specified the type of the Link.
+**Now:** We have 1 table for each type of Link, with a base `Link` table for all record.
+
+## Specify any custom configuration
+
+Have a look at `LinkableMigrationTask`. There are some configuration properties defined in there:
+
+- `$link_mapping`
+- `$email_mapping`
+- `$external_mapping`
+- `$file_mapping`
+- `$phone_mapping`
+- `$sitetree_mapping`
+
+Each of these specifies how an original field from the `LinkableLink` table will map to one of the new LinkField tables.
+
+If you previously had some custom fields that needed to be available across **all** Link types, then you're (probably)
+going to add this as an extension on the (base) `Link` class. This is going to mean that the new fields will be added
+to the `LinkField_Link` table. This means that you need to update the configuration for `$link_mapping` so that we
+correctly migrate those field values into the `LinkField_Link` table.
+
+If you had/have a field that you only want displayed on (say) SiteTree links, then you would want to add that extension
+to `SiteTreeLink`. This would create new fields in the `LinkField_SiteTreeLink` table, which will mean you need to
+also update the config for `$sitetree_mapping`.
+
+It's important that you get the correct mappings to the correct tables.

--- a/src/Models/EmailLink.php
+++ b/src/Models/EmailLink.php
@@ -12,13 +12,11 @@ use SilverStripe\Forms\FieldList;
  */
 class EmailLink extends Link
 {
-
     private static $table_name = 'LinkField_EmailLink';
 
     private static $db = [
         'Email' => 'Varchar(255)'
     ];
-
 
     public function generateLinkDescription(array $data): string
     {

--- a/src/Models/ExternalLink.php
+++ b/src/Models/ExternalLink.php
@@ -9,7 +9,6 @@ namespace SilverStripe\LinkField\Models;
  */
 class ExternalLink extends Link
 {
-
     private static $table_name = 'LinkField_ExternalLink';
 
     private static $db = [

--- a/src/Models/FileLink.php
+++ b/src/Models/FileLink.php
@@ -14,7 +14,6 @@ use SilverStripe\LinkField\Type\Type;
  */
 class FileLink extends Link
 {
-
     private static $table_name = 'LinkField_FileLink';
 
     private static $has_one = [

--- a/src/Models/Link.php
+++ b/src/Models/Link.php
@@ -26,7 +26,6 @@ use SilverStripe\View\Requirements;
  */
 class Link extends DataObject implements JsonData, Type
 {
-
     private static $table_name = 'LinkField_Link';
 
     private static $db = [
@@ -42,7 +41,6 @@ class Link extends DataObject implements JsonData, Type
      * @var string
      */
     private $linkType;
-
 
     public function defineLinkTypeRequirements()
     {

--- a/src/Models/PhoneLink.php
+++ b/src/Models/PhoneLink.php
@@ -12,7 +12,6 @@ use SilverStripe\Forms\FieldList;
  */
 class PhoneLink extends Link
 {
-
     private static $table_name = 'LinkField_PhoneLink';
 
     private static $db = [

--- a/src/Models/PhoneLink.php
+++ b/src/Models/PhoneLink.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace SilverStripe\LinkField\Models;
+
+use SilverStripe\Forms\EmailField;
+use SilverStripe\Forms\FieldList;
+
+/**
+ * A link to a phone number
+ *
+ * @property string $Phone
+ */
+class PhoneLink extends Link
+{
+
+    private static $table_name = 'LinkField_PhoneLink';
+
+    private static $db = [
+        'Phone' => 'Varchar(255)'
+    ];
+
+    public function generateLinkDescription(array $data): string
+    {
+        return isset($data['Phone']) ? $data['Phone'] : '';
+    }
+
+    public function getURL()
+    {
+        return $this->Phone ? sprintf('tel:%s', $this->Phone) : '';
+    }
+}

--- a/src/Models/SiteTreeLink.php
+++ b/src/Models/SiteTreeLink.php
@@ -16,7 +16,6 @@ use SilverStripe\Forms\TreeDropdownField;
  */
 class SiteTreeLink extends Link
 {
-
     private static $table_name = 'LinkField_SiteTreeLink';
 
     private static $db = [

--- a/src/Tasks/LinkableMigrationTask.php
+++ b/src/Tasks/LinkableMigrationTask.php
@@ -1,0 +1,382 @@
+<?php
+
+namespace SilverStripe\LinkField\Tasks;
+
+use Exception;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\BuildTask;
+use SilverStripe\LinkField\Models\EmailLink;
+use SilverStripe\LinkField\Models\ExternalLink;
+use SilverStripe\LinkField\Models\FileLink;
+use SilverStripe\LinkField\Models\Link;
+use SilverStripe\LinkField\Models\PhoneLink;
+use SilverStripe\LinkField\Models\SiteTreeLink;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\Queries\SQLInsert;
+use SilverStripe\ORM\Queries\SQLSelect;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * @codeCoverageIgnore
+ */
+class LinkableMigrationTask extends BuildTask
+{
+
+    private const TABLE_BASE = 'LinkableLink';
+    private const TABLE_LIVE = 'LinkableLink_Live';
+    private const TABLE_VERSIONS = 'LinkableLink_Versions';
+
+    private const TABLE_MAP_LINK = [
+        self::TABLE_BASE => 'LinkField_Link',
+        self::TABLE_LIVE => 'LinkField_Link_Live',
+        self::TABLE_VERSIONS => 'LinkField_Link_Versions',
+    ];
+
+    private const TABLE_MAP_EMAIL_LINK = [
+        self::TABLE_BASE => 'LinkField_EmailLink',
+        self::TABLE_LIVE => 'LinkField_EmailLink_Live',
+        self::TABLE_VERSIONS => 'LinkField_EmailLink_Versions',
+    ];
+
+    private const TABLE_MAP_EXTERNAL_LINK = [
+        self::TABLE_BASE => 'LinkField_ExternalLink',
+        self::TABLE_LIVE => 'LinkField_ExternalLink_Live',
+        self::TABLE_VERSIONS => 'LinkField_ExternalLink_Versions',
+    ];
+
+    private const TABLE_MAP_FILE_LINK = [
+        self::TABLE_BASE => 'LinkField_FileLink',
+        self::TABLE_LIVE => 'LinkField_FileLink_Live',
+        self::TABLE_VERSIONS => 'LinkField_FileLink_Versions',
+    ];
+
+    private const TABLE_MAP_PHONE_LINK = [
+        self::TABLE_BASE => 'LinkField_PhoneLink',
+        self::TABLE_LIVE => 'LinkField_PhoneLink_Live',
+        self::TABLE_VERSIONS => 'LinkField_PhoneLink_Versions',
+    ];
+
+    private const TABLE_MAP_SITE_TREE_LINK = [
+        self::TABLE_BASE => 'LinkField_SiteTreeLink',
+        self::TABLE_LIVE => 'LinkField_SiteTreeLink_Live',
+        self::TABLE_VERSIONS => 'LinkField_SiteTreeLink_Versions',
+    ];
+
+    private static $versions_mapping_global = [
+        'RecordID' => 'RecordID',
+        'Version' => 'Version',
+    ];
+
+    private static $versions_mapping_base_only = [
+        'WasPublished' => 'WasPublished',
+        'WasDeleted' => 'WasDeleted',
+        'WasDraft' => 'WasDraft',
+        'AuthorID' => 'AuthorID',
+        'PublisherID' => 'PublisherID',
+    ];
+
+    /**
+     * LinkableLink field => LinkField_Link field
+     */
+    private static $link_mapping = [
+        'ID' => 'ID',
+        'LastEdited' => 'LastEdited',
+        'Created' => 'Created',
+        'Title' => 'Title',
+        'OpenInNewWindow' => 'OpenInNew',
+    ];
+
+    /**
+     * LinkableLink field => LinkField_EmailLink field
+     */
+    private static $email_mapping = [
+        'ID' => 'ID',
+        'Email' => 'Email',
+    ];
+
+    /**
+     * LinkableLink field => LinkField_ExternalLink field
+     */
+    private static $external_mapping = [
+        'ID' => 'ID',
+        'URL' => 'ExternalUrl',
+    ];
+
+    /**
+     * LinkableLink field => LinkField_FileLink field
+     */
+    private static $file_mapping = [
+        'ID' => 'ID',
+        'FileID' => 'FileID',
+    ];
+
+    /**
+     * LinkableLink field => LinkField_PhoneLink field
+     */
+    private static $phone_mapping = [
+        'ID' => 'ID',
+        'Phone' => 'Phone',
+    ];
+
+    /**
+     * LinkableLink field => LinkField_SiteTreeLink field
+     */
+    private static $sitetree_mapping = [
+        'ID' => 'ID',
+        'SiteTreeID' => 'PageID',
+        'Anchor' => 'Anchor',
+    ];
+
+    /**
+     * @var string
+     */
+    private static $segment = 'linkable-migration-task';
+
+    /**
+     * @var string
+     */
+    protected $title = 'Linkable Migration Task';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Truncate LinkField records and migrate from Linkable records';
+
+    /**
+     * @param HTTPRequest $request
+     */
+    public function run($request)
+    {
+        // Check that we have matching Versioned states between Linkable and LinkField
+        if (!$this->versionedStatusMatches()) {
+            throw new Exception(
+                'Linkable and LinkField do not have matching Versioned applications. Make sure that both are'
+                . ' either un-Versioned or Versioned'
+            );
+        }
+
+        // If we're un-Versioned then it's just going to be the base table
+        $tables = [
+            self::TABLE_BASE,
+        ];
+
+        // Since we passed the versionedStatusMatches() step, then we can just check if Link is Versioned, and we can
+        // safely assume that the Linkable Versioned tables also exist
+        if (Link::singleton()->hasExtension(Versioned::class)) {
+            // Add the _Live and _Versions tables to the list of things we need to copy
+            $tables[] = self::TABLE_LIVE;
+            $tables[] = self::TABLE_VERSIONS;
+        }
+
+        // We expect your LinkField tables to be completely clear before migration is kicked off
+        $this->truncateLinkFieldTables();
+
+        foreach ($tables as $table) {
+            // Grab any/all records from the desired table (base, live, versions)
+            $linkableResults = SQLSelect::create('*', $table)->execute();
+
+            // Nothing to see here
+            if ($linkableResults->numRecords() === 0) {
+                echo sprintf("Nothing to process for `%s`\r\n", $table);
+
+                continue;
+            }
+
+            echo sprintf("Processing `%s`\r\n", $table);
+
+            // Loop through each DB record
+            foreach ($linkableResults as $linkableArray) {
+                // We now need to determine what type of Link the original Linkable record was, because we're going to
+                // have to process each of those slightly differently
+                switch ($linkableArray['Type']) {
+                    case 'Email':
+                        $this->insertEmail($linkableArray, $table);
+
+                        break;
+                    case 'URL':
+                        $this->insertExternal($linkableArray, $table);
+
+                        break;
+                    case 'File':
+                        $this->insertFile($linkableArray, $table);
+
+                        break;
+                    case 'Phone':
+                        $this->insertPhone($linkableArray, $table);
+
+                        break;
+                    case 'SiteTree':
+                        $this->insertSiteTree($linkableArray, $table);
+
+                        break;
+                }
+            }
+
+            echo sprintf("Finished processing `%s`\r\n", $table);
+        }
+    }
+
+    private function versionedStatusMatches(): bool
+    {
+        // Check to see if there is the existence of a _Live table for Linkable (indicating that it was Versioned)
+        $wasVersioned = DB::query('SHOW TABLES LIKE \'LinkableLink_Live\';')->numRecords() > 0;
+        $isVersioned = Link::singleton()->hasExtension(Versioned::class);
+
+        return $wasVersioned === $isVersioned;
+    }
+
+    private function truncateLinkFieldTables(): void
+    {
+        $tables = [
+            'LinkField_Link',
+            'LinkField_EmailLink',
+            'LinkField_ExternalLink',
+            'LinkField_FileLink',
+            'LinkField_PhoneLink',
+            'LinkField_SiteTreeLink',
+        ];
+        $versioned = [
+            '_Live',
+            '_Versions',
+        ];
+        $isVersioned = Link::singleton()->hasExtension(Versioned::class);
+
+        foreach ($tables as $table) {
+            DB::query(sprintf('TRUNCATE TABLE %s', $table));
+
+            if (!$isVersioned) {
+                continue;
+            }
+
+            foreach ($versioned as $append) {
+                DB::query(sprintf('TRUNCATE TABLE %s%s', $table, $append));
+            }
+        }
+    }
+
+    private function getAssignmentsForMapping(array $config, array $linkableArray, string $originTable): array
+    {
+        // If we're processing the _Versions table, then we need to add all the Version table field assignments
+        if ($originTable === self::TABLE_VERSIONS) {
+            $config += $this->config()->get('versions_mapping_global');
+        }
+
+        // We're now going to start assigning values to the new fields (as you've specified in your config)
+        $assignments = [];
+
+        // Loop through each config
+        foreach ($config as $oldField => $newField) {
+            // Assign the new field to equal whatever value was in the original record (based on the old field name)
+            $assignments[$newField] = $linkableArray[$oldField];
+        }
+
+        return $assignments;
+    }
+
+    private function insertLink(string $className, array $linkableArray, string $originTable): void
+    {
+        $config = $this->config()->get('link_mapping');
+
+        // If we're processing the _Versions table, then we need to add all the Version table field assignments that are
+        // specifically for the base record (such as all the "WasPublished", "WasDraft", etc fields)
+        if ($originTable === self::TABLE_VERSIONS) {
+            $config += $this->config()->get('versions_mapping_global');
+        }
+
+        // These assignments are based on our config
+        $assignments = $this->getAssignmentsForMapping(
+            $config,
+            $linkableArray,
+            $originTable
+        );
+        // We also need to add ClassName for the base table, and this is not configurable
+        $assignments['ClassName'] = $className;
+
+        // Find out what the corresponding table is for the origin table
+        $newTable = self::TABLE_MAP_LINK[$originTable];
+
+        // Insert our new record
+        SQLInsert::create($newTable, $assignments)->execute();
+    }
+
+    private function insertEmail(array $linkableArray, string $originTable): void
+    {
+        // Insert the base record for this EmailLink
+        $this->insertLink(EmailLink::class, $linkableArray, $originTable);
+
+        $newTable = self::TABLE_MAP_EMAIL_LINK[$originTable];
+
+        $assignments = $this->getAssignmentsForMapping(
+            $this->config()->get('email_mapping'),
+            $linkableArray,
+            $originTable
+        );
+
+        SQLInsert::create($newTable, $assignments)->execute();
+    }
+
+    private function insertExternal(array $linkableArray, string $originTable): void
+    {
+        // Insert the base record for this ExternalLink
+        $this->insertLink(ExternalLink::class, $linkableArray, $originTable);
+
+        $newTable = self::TABLE_MAP_EXTERNAL_LINK[$originTable];
+
+        $assignments = $this->getAssignmentsForMapping(
+            $this->config()->get('external_mapping'),
+            $linkableArray,
+            $originTable
+        );
+
+        SQLInsert::create($newTable, $assignments)->execute();
+    }
+
+    private function insertFile(array $linkableArray, string $originTable): void
+    {
+        // Insert the base record for this FileLink
+        $this->insertLink(FileLink::class, $linkableArray, $originTable);
+
+        $newTable = self::TABLE_MAP_FILE_LINK[$originTable];
+
+        $assignments = $this->getAssignmentsForMapping(
+            $this->config()->get('file_mapping'),
+            $linkableArray,
+            $originTable
+        );
+
+        SQLInsert::create($newTable, $assignments)->execute();
+    }
+
+    private function insertPhone(array $linkableArray, string $originTable): void
+    {
+        // Insert the base record for this PhoneLink
+        $this->insertLink(PhoneLink::class, $linkableArray, $originTable);
+
+        $newTable = self::TABLE_MAP_PHONE_LINK[$originTable];
+
+        $assignments = $this->getAssignmentsForMapping(
+            $this->config()->get('phone_mapping'),
+            $linkableArray,
+            $originTable
+        );
+
+        SQLInsert::create($newTable, $assignments)->execute();
+    }
+
+    private function insertSiteTree(array $linkableArray, string $originTable): void
+    {
+        // Insert the base record for this SiteTreeLink
+        $this->insertLink(SiteTreeLink::class, $linkableArray, $originTable);
+
+        $newTable = self::TABLE_MAP_SITE_TREE_LINK[$originTable];
+
+        $assignments = $this->getAssignmentsForMapping(
+            $this->config()->get('sitetree_mapping'),
+            $linkableArray,
+            $originTable
+        );
+
+        SQLInsert::create($newTable, $assignments)->execute();
+    }
+
+}

--- a/src/Tasks/LinkableMigrationTask.php
+++ b/src/Tasks/LinkableMigrationTask.php
@@ -378,5 +378,4 @@ class LinkableMigrationTask extends BuildTask
 
         SQLInsert::create($newTable, $assignments)->execute();
     }
-
 }

--- a/tests/php/Models/LinkTest.php
+++ b/tests/php/Models/LinkTest.php
@@ -9,6 +9,7 @@ use SilverStripe\LinkField\Models\EmailLink;
 use SilverStripe\LinkField\Models\ExternalLink;
 use SilverStripe\LinkField\Models\FileLink;
 use SilverStripe\LinkField\Models\Link;
+use SilverStripe\LinkField\Models\PhoneLink;
 use SilverStripe\LinkField\Models\SiteTreeLink;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ValidationException;
@@ -76,6 +77,7 @@ class LinkTest extends SapphireTest
             [EmailLink::class, false],
             [ExternalLink::class, false],
             [FileLink::class, false],
+            [PhoneLink::class, false],
             [SiteTreeLink::class, false],
             [Link::class, true],
         ];


### PR DESCRIPTION
* Linkable had a concept of a "Phone" link, which didn't currently exist in LinkField. So I've added that. It's really just a duplicate of `EmailField`, but it returns a `tel` instead of a `mailto`.
* Added some instructions based on what I found from migrating my own project. These steps may not be completely comprehensive, but I've tried to at least indicate areas that might need attention.
* Supports `Versioned` and `un-Versioned`. However, we expect the `Versioned` state between legacy (`Linkable`) and `LinkField` to match.