### PR TITLE
MNT Wrap composer commands in a code area

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ Installation via composer.
 
 ### GraphQL v4 - Silverstripe 4
 
-`composer require silverstripe/linkfield`
+```sh
+composer require silverstripe/linkfield
+```
 
 ### GraphQL v3 - Silverstripe 4
 
-`composer require silverstripe/linkfield:^1`
+```sh
+composer require silverstripe/linkfield:^1
+```
 
 ## Sample usage
 


### PR DESCRIPTION
This makes it easier to use, since github provides a handy _copy_ button for code blocks.