### PR TITLE
BUG: List types can now be disabled via configuration (existing config, missing feature).

### DIFF
--- a/src/Type/Registry.php
+++ b/src/Type/Registry.php
@@ -50,6 +50,11 @@ class Registry
         $typeDefinitions = self::config()->get('types');
 
         foreach ($typeDefinitions as $key => $def) {
+            // This link type is disabled, so we can skip it
+            if (!array_key_exists('enabled', $def) || !$def['enabled']) {
+                continue;
+            }
+
             $types[$key] = $this->definitionToType($def);
         }
 


### PR DESCRIPTION
# BUG: List types can now be disabled via configuration (existing config, missing feature).

* List types can now be disabled via configuration (existing config, missing feature)

Broken tests are not related to this change-set but rather to https://github.com/silverstripe/.github/issues/48