### PR TITLE
ENH: Query string support.

### DIFF
--- a/src/Models/ExternalLink.php
+++ b/src/Models/ExternalLink.php
@@ -22,6 +22,6 @@ class ExternalLink extends Link
 
     public function getURL()
     {
-        return $this->ExternalUrl;
+        return (string) $this->ExternalUrl;
     }
 }

--- a/tests/php/Models/LinkTest.php
+++ b/tests/php/Models/LinkTest.php
@@ -204,4 +204,85 @@ class LinkTest extends SapphireTest
             ],
         ];
     }
+
+    /**
+     * @param string $identifier
+     * @param string $class
+     * @param string $expected
+     * @return void
+     * @dataProvider linkUrlCasesDataProvider
+     */
+    public function testGetUrl(string $identifier, string $class, string $expected): void
+    {
+        /** @var Link $link */
+        $link = $this->objFromFixture($class, $identifier);
+
+        $this->assertSame($expected, $link->getURL(), 'We expect specific URL value');
+    }
+
+    public function linkUrlCasesDataProvider(): array
+    {
+        return [
+            'internal link / page only' => [
+                'page-link-page-only',
+                SiteTreeLink::class,
+                '/page-1/',
+            ],
+            'internal link / anchor only' => [
+                'page-link-anchor-only',
+                SiteTreeLink::class,
+                '#my-anchor',
+            ],
+            'internal link / query string only' => [
+                'page-link-query-string-only',
+                SiteTreeLink::class,
+                '?param1=value1&param2=option2',
+            ],
+            'internal link / with anchor' => [
+                'page-link-with-anchor',
+                SiteTreeLink::class,
+                '/page-1/#my-anchor',
+            ],
+            'internal link / with query string' => [
+                'page-link-with-query-string',
+                SiteTreeLink::class,
+                '/page-1/?param1=value1&param2=option2',
+            ],
+            'internal link / with query string and anchor' => [
+                'page-link-with-query-string-and-anchor',
+                SiteTreeLink::class,
+                '/page-1/?param1=value1&param2=option2#my-anchor',
+            ],
+            'email link / with email' => [
+                'email-link-with-email',
+                EmailLink::class,
+                'mailto:maxime@silverstripe.com',
+            ],
+            'email link / no email' => [
+                'email-link-no-email',
+                EmailLink::class,
+                '',
+            ],
+            'external link / with URL' => [
+                'external-link-with-url',
+                ExternalLink::class,
+                'https://google.com',
+            ],
+            'external link / no URL' => [
+                'external-link-no-url',
+                ExternalLink::class,
+                '',
+            ],
+            'phone link / with phone' => [
+                'phone-link-with-phone',
+                PhoneLink::class,
+                'tel:+64 4 978 7330',
+            ],
+            'phone link / no phone' => [
+                'phone-link-no-phone',
+                PhoneLink::class,
+                '',
+            ],
+        ];
+    }
 }

--- a/tests/php/Models/LinkTest.yml
+++ b/tests/php/Models/LinkTest.yml
@@ -1,11 +1,55 @@
+SilverStripe\CMS\Model\SiteTree:
+  page-1:
+    Title: 'Page1'
+    URLSegment: 'page-1'
+
 SilverStripe\LinkField\Models\Link:
   link-1:
-    Title: Link1
+    Title: 'Link1'
 
 SilverStripe\LinkField\Models\SiteTreeLink:
   page-link-1:
-    Title: PageLink1
+    Title: 'PageLink1'
+  page-link-page-only:
+    Title: 'PageLinkPageOnly'
+    Page: =>SilverStripe\CMS\Model\SiteTree.page-1
+  page-link-anchor-only:
+    Title: 'PageLinkAnchorOnly'
+    Anchor: 'my-anchor'
+  page-link-query-string-only:
+    Title: 'PageLinkQueryStringOnly'
+    QueryString: 'param1=value1&param2=option2'
+  page-link-with-anchor:
+    Title: 'PageLinkWithAnchor'
+    Anchor: 'my-anchor'
+    Page: =>SilverStripe\CMS\Model\SiteTree.page-1
+  page-link-with-query-string:
+    Title: 'PageLinkWithQueryString'
+    QueryString: 'param1=value1&param2=option2'
+    Page: =>SilverStripe\CMS\Model\SiteTree.page-1
+  page-link-with-query-string-and-anchor:
+    Title: 'PageLinkWithQueryStringAndAnchor'
+    QueryString: 'param1=value1&param2=option2'
+    Anchor: 'my-anchor'
+    Page: =>SilverStripe\CMS\Model\SiteTree.page-1
 
-SilverStripe\CMS\Model\SiteTree:
-  page-1:
-    Title: Page1
+SilverStripe\LinkField\Models\EmailLink:
+  email-link-with-email:
+    Title: 'EmailLinkWithEmail'
+    Email: 'maxime@silverstripe.com'
+  email-link-no-email:
+    Title: 'EmailLinkNoEmail'
+
+SilverStripe\LinkField\Models\ExternalLink:
+  external-link-with-url:
+    Title: 'ExternalLinkWithUrl'
+    ExternalUrl: 'https://google.com'
+  external-link-no-url:
+    Title: 'ExternalLinkNoUrl'
+
+SilverStripe\LinkField\Models\PhoneLink:
+  phone-link-with-phone:
+    Title: 'PhoneLinkWithPhone'
+    Phone: '+64 4 978 7330'
+  phone-link-no-phone:
+    Title: 'PhoneLinkNoPhone'


### PR DESCRIPTION
# ENH: Query string support.

* add support to manage query strings for internal links (keeping this separate from the anchor as the anchor field is intended for anchors only)
* add tests for getURL() methods
* make these methods have consistent return values