### PR TITLE
ENH Allow projects to define their own subclass templates

### DIFF
--- a/src/Models/Link.php
+++ b/src/Models/Link.php
@@ -259,7 +259,9 @@ class Link extends DataObject
      */
     public function forTemplate()
     {
-        return $this->renderWith([self::class]);
+        // First look for a subclass of the email template e.g. EmailLink.ss which may be defined
+        // in a project. Fallback to using the generic Link.ss template which this module provides
+        return $this->renderWith([static::class, self::class]);
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-linkfield/issues/84

Currently you're stuck having to use either the default `Link.ss` template or overriding all Link templates globally by creating a 'Link.ss' in your project

This allows you to defined templates for individual Link types in your project