### PR TITLE
NEW Add HasOneCanViewValidator

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -5,5 +5,4 @@ use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
 
 // Avoid creating global variables
 call_user_func(function () {
-
 });

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,0 +1,3 @@
+en:
+  SilverStripe\LinkField\Validators\HasOneCanViewValidator:
+    CANNOTBEVIEWED: '{name} cannot be viewed'

--- a/src/Models/SiteTreeLink.php
+++ b/src/Models/SiteTreeLink.php
@@ -8,6 +8,8 @@ use SilverStripe\Control\Controller;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\TreeDropdownField;
+use SilverStripe\LinkField\Validators\HasOneCanViewValidator;
+use SilverStripe\Forms\CompositeValidator;
 
 /**
  * A link to a Page in the CMS
@@ -127,5 +129,12 @@ class SiteTreeLink extends Link
 
         // Use page title as a default value in case CMS user didn't provide the title
         return $page->Title;
+    }
+
+    public function getCMSCompositeValidator(): CompositeValidator
+    {
+        $validator = parent::getCMSCompositeValidator();
+        $validator->addValidator(HasOneCanViewValidator::create(['PageID']));
+        return $validator;
     }
 }

--- a/src/Validators/HasOneCanViewValidator.php
+++ b/src/Validators/HasOneCanViewValidator.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SilverStripe\LinkField\Validators;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Forms\Validator;
+use SilverStripe\Forms\FormField;
+
+/**
+ * Call a canView() check to validate a has_one relation
+ */
+class HasOneCanViewValidator extends Validator
+{
+    /**
+     * List of has_one relation fields (with 'ID' suffixed) that need to pass a canView() check
+     */
+    private array $relationFields;
+
+    /**
+     * Pass each field to be validated as a separate argument to the constructor
+     * of this object. (an array of elements are ok).
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $relationFields = func_get_args();
+        if (isset($relationFields[0]) && is_array($relationFields[0])) {
+            $relationFields = $relationFields[0];
+        }
+        foreach ($relationFields as $i => $relationField) {
+            if (!preg_match('#ID$#', $relationField)) {
+                $relationFields[$i] .= 'ID';
+            }
+        }
+        $this->relationFields = $relationFields;
+    }
+
+    /**
+     * Allows validation of fields via specification of a php function for
+     * validation which is executed after the form is submitted.
+     *
+     * @param array $data
+     * @return boolean
+     */
+    public function php($data)
+    {
+        $valid = true;
+        $fields = $this->form->Fields();
+        $dataObjectClassName = get_class($this->form->getRecord());
+        $hasOnes = Config::inst()->get($dataObjectClassName, 'has_one');
+
+        foreach ($this->relationFields as $fieldName) {
+            if ($fieldName instanceof FormField) {
+                $formField = $fieldName;
+                $fieldName = $fieldName->getName();
+            } else {
+                $formField = $fields->dataFieldByName($fieldName);
+            }
+
+            if (!$formField) {
+                continue;
+            }
+
+            $value ??= $data[$fieldName];
+            if (!$value) {
+                continue;
+            }
+
+            $relation = preg_replace('#ID$#', '', $fieldName);
+            $relationClassName = $hasOnes[$relation];
+            $relationObject = $relationClassName::get()->byID($value);
+
+            if ($relationObject && $relationObject->canView()) {
+                // It's valid
+                // Note if $relationObject is null then still fail this CanView validator the same
+                // way so that user cannot tell if the relation exists or not
+                continue;
+            }
+
+            $errorMessage = _t(
+                __CLASS__ . '.CANNOTBEVIEWED',
+                '{name} cannot be viewed',
+                [
+                    'name' => strip_tags(
+                        '"' . ($formField->Title() ? $formField->Title() : $fieldName) . '"'
+                    )
+                ]
+            );
+            if ($msg = $formField->getCustomValidationMessage()) {
+                $errorMessage = $msg;
+            }
+            $this->validationError($fieldName, $errorMessage, 'required');
+            $valid = false;
+        }
+
+        return $valid;
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-linkfield/issues/84

This one probably shouldn't be merged, just an idea I had, though soon realised after implementation it's kind of pointless because you can already see protected pages in the SiteTree and TreeDropdownfield, just you cannot view them as you get a 'Forbidden' red toast popup

Requires the new Link::validate() method from https://github.com/silverstripe/silverstripe-linkfield/pull/85 in order to function