### PR TITLE
NEW Linkfield ownership

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -5,5 +5,4 @@ use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
 
 // Avoid creating global variables
 call_user_func(function () {
-
 });

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -21,3 +21,7 @@ SilverStripe\CMS\Forms\AnchorSelectorField:
 SilverStripe\LinkField\Form\FormFactory:
   extensions:
     - SilverStripe\LinkField\Extensions\FormFactoryExtension
+
+SilverStripe\ORM\DataObject:
+  extensions:
+    - SilverStripe\LinkField\Extensions\DataObjectExtension

--- a/src/Extensions/DataObjectExtension.php
+++ b/src/Extensions/DataObjectExtension.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SilverStripe\LinkField\Extensions;
+
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\LinkField\Models\Link;
+use SilverStripe\LinkField\Models\LinkArea;
+
+class DataObjectExtension extends DataExtension
+{
+    public function onAfterWrite(): void
+    {
+        // Using onAfterWrite instead of onBeforeWrite to ensure that $this->owner->ID is not zero when creating new objects
+        parent::onAfterWrite();
+        foreach ($this->owner->hasOne() as $relation => $relationClassName) {
+            $relationField = $relation . 'ID';
+            $relationID = $this->owner->$relationField;
+            if (!$relationID) {
+                continue;
+            }
+            if (!is_a($relationClassName, Link::class, true) && !is_a($relationClassName, LinkArea::class, true)) {
+                continue;
+            }
+            // skip for the has_one:LinkArea relation on Link
+            if (is_a($this->owner, Link::class) && $relation === 'LinkArea') {
+                continue;
+            }
+            $relationObj = $relationClassName::get()->byID($relationID);
+            if ($relationObj === null) {
+                // could throw an Exception here, though not sure how if user would be able to fix it
+                continue;
+            }
+            $doWrite = false;
+            if ($relationObj->OwnerID !== $this->owner->ID) {
+                $relationObj->OwnerID = $this->owner->ID;
+                $doWrite = true;
+            }
+            if ($relationObj->OwnerClassName !== $this->owner->ClassName) {
+                $relationObj->OwnerClassName = $this->owner->ClassName;
+                $doWrite = true;
+            }
+            if ($doWrite) {
+                $relationObj->write();
+            }
+        }
+    }
+}

--- a/src/Extensions/LinkObjectExtension.php
+++ b/src/Extensions/LinkObjectExtension.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace SilverStripe\LinkField\Extensions;
+
+use SilverStripe\LinkField\Models\Link;
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * This is only intended to be added to Link and LinkArea
+ * Implemented as an extension rather than base class so it doesn't create an extra base table that needs to be joined
+ */
+class LinkObjectExtension extends DataExtension
+{
+    private static array $db = [
+        'OwnerID' => 'Int',
+        'OwnerClassName' => 'Varchar',
+    ];
+
+    public function canView($member = null)
+    {
+        return $this->canCheck('canView', $member);
+    }
+
+    public function canCreate($member = null)
+    {
+        return $this->canCheck('canCreate', $member);
+    }
+
+    public function canEdit($member = null)
+    {
+        return $this->canCheck('canEdit', $member);
+    }
+
+    public function canDelete($member = null)
+    {
+        return $this->canCheck('canDelete', $member);
+    }
+
+    private function canCheck(string $canMethod, $member)
+    {
+        if (!$member) {
+            $member = Security::getCurrentUser();
+        }
+        $extended = $this->extendedCan($canMethod, $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+        $owner = $this->getOwningDataObject();
+        if ($owner) {
+            return $owner->$canMethod($member);
+        }
+        return parent::$canMethod($member);
+    }
+
+    private function getOwningDataObject(): ?DataObject
+    {
+        // Thismethod is not called getOwner() because of existing Extension::getOwner() method
+        //
+        // If this is a Link, and LinkArea is set on it return that
+        if (is_a($this->owner, Link::class, true)) {
+            $linkArea = $this->owner->LinkArea();
+            if ($linkArea && $linkArea->exists()) {
+                return $linkArea;
+            }
+        }
+        // Otherwise look for the ownerID + ownerClassName
+        // These are set in DataObjectExtension::onAfterWrite()
+        $ownerID = $this->owner->OwnerID;
+        $ownerClassName = $this->owner->OwnerClassName;
+        if ($ownerID === 0 || $ownerClassName === '') {
+            return null;
+        }
+        return $ownerClassName::get()->byID($ownerID);
+    }
+}

--- a/src/Models/Link.php
+++ b/src/Models/Link.php
@@ -16,6 +16,9 @@ use SilverStripe\LinkField\Type\Type;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\View\Requirements;
+use SilverStripe\LinkField\Extensions\LinkObjectExtension;
+use SilverStripe\Versioned\Versioned;
+use SilverStripe\LinkField\Models\LinkArea;
 
 /**
  * A Link Data Object. This class should be a subclass, and you should never directly interact with a plain Link
@@ -31,6 +34,15 @@ class Link extends DataObject implements JsonData, Type
     private static array $db = [
         'Title' => 'Varchar',
         'OpenInNew' => 'Boolean',
+    ];
+
+    private static array $has_one = [
+        'LinkArea' => LinkArea::class
+    ];
+
+    private static array $extensions = [
+        Versioned::class,
+        LinkObjectExtension::class,
     ];
 
     /**

--- a/src/Models/LinkArea.php
+++ b/src/Models/LinkArea.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SilverStripe\LinkField\Models;
+
+use SilverStripe\LinkField\Models\Link;
+use SilverStripe\LinkField\Extensions\LinkObjectExtension;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+class LinkArea extends DataObject
+{
+    private static $table_name = 'LinkField_LinkArea';
+
+    private static array $has_many = [
+        'Links' => Link::class,
+    ];
+
+    private static array $owns = [
+        'Links',
+    ];
+
+    private static array $cascade_deletes = [
+        'Links',
+    ];
+
+    private static array $cascade_duplicates = [
+        'Links',
+    ];
+
+    private static array $extensions = [
+        Versioned::class,
+        LinkObjectExtension::class,
+    ];
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-linkfield/issues/5

Also implements https://github.com/silverstripe/silverstripe-linkfield/issues/12

**In peer review because looking for initial feedback - have I overlooked something really obvious?**

This is a draft PR that's just testing out the idea of using a LinkArea to manage the has_many relationships similar to ElementalArea in elemental. Advantage of using the extra layer is that it allows you to effectively add multiple "has_many" relations of Link::class and have them correctly assigned to each of the has_many relations.

Documentation would instruct you to add you Links and LinkArea's to $has_one + $owns + $cascade_deletes + $cascase_duplicates

A Page in a project would look something like this if it had two Link's and two LinkArea's

```php
class Page extends SiteTree
{
    private static array $has_one = [
        'MyLinkOne' => Link::class,
        'MyLinkTwo' => Link::class,
        'MyLinkAreaOne' => LinkArea::class,
        'MyLinkAreaTwo' => LinkArea::class,
    ];

    private static array $owns = [
        'MyLinkOne',
        'MyLinkTwo',
        'MyLinkAreaOne',
        'MyLinkAreaTwo',
    ];

    private static array $cascade_deletes = [
        'MyLinkOne',
        'MyLinkTwo',
        'MyLinkAreaOne',
        'MyLinkAreaTwo',
    ];

    private static array $cascade_duplicates = [
        'MyLinkOne',
        'MyLinkTwo',
        'MyLinkAreaOne',
        'MyLinkAreaTwo',
    ];
}

```

Adding multiple has_many's of the same type normally isn't possible because you'll have something like this:

```
Page
  $has_many = [
    MyThings => MyDataObject::class,
    MoreThings => MyDataObject::class,
  ]

MyDataObject
  $has_one = [
    Page => Page::class
  ];
```

And you'll get $myDataObject->PageID = 123 - but there's no way to know if it should belong to the 'MyThings' or the 'MoreThings' relationship on Page

The official way to solve "multiple has_manys of the same type" this is with [dot notation](https://docs.silverstripe.org/en/5/developer_guides/model/relations/#dot-notation) where the the corresponding has_one relationship is suffixed to the classname of has_many relationship. In this instance it would look something like this (excuse my use of RelOne and RelTwo, I couldn't think of proper naming here):

```
Page
  $has_many = [
    MyThings => MyDataObject::class . '.RelOne',
    MoreThings => MyDataObject::class . '.RelTwo',
  ]

MyDataObject
  $has_one = [
    RelOne => Page::class,
    RelTwo => Page::class,
  ];
```

However in the linkfield context we cannot use dot-notation, because "MyDataObject" would be "Link" and we can't set the $has_one's on Link since it has no knowledge of project code. We'd need to ask people to add the $has_ones to Link via extensions which is very clunky.

Note there's somethings to do with unit testing that needs to be extracted from https://github.com/silverstripe/silverstripe-linkfield/pull/90 before closing that PR