### PR TITLE
FIX Don't render links that don't exist

### DIFF
--- a/templates/SilverStripe/LinkField/Models/Link.ss
+++ b/templates/SilverStripe/LinkField/Models/Link.ss
@@ -1,1 +1,3 @@
-<a href="$URL" <% if $OpenInNew %>target="_blank" rel="noopener noreferrer"<% end_if %>>$DisplayTitle</a>
+<% if $exists %>
+    <a href="$URL" <% if $OpenInNew %>target="_blank" rel="noopener noreferrer"<% end_if %>>$DisplayTitle</a>
+<% end_if %>


### PR DESCRIPTION
## Issue
- https://github.com/silverstripe/silverstripe-linkfield/issues/129