### PR TITLE
ENH Remove LinkFieldController from cms menu

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,8 +1,6 @@
 <?php
 
-use SilverStripe\Core\Manifest\ModuleLoader;
-use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
+use SilverStripe\Admin\CMSMenu;
+use SilverStripe\LinkField\Controllers\LinkFieldController;
 
-// Avoid creating global variables
-call_user_func(function () {
-});
+CMSMenu::remove_menu_class(LinkFieldController::class);


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-linkfield/issues/143

This PR:
- Removes LinkFieldController from cms menu
- Removes some dead code and unused imports from _config.php