### PR TITLE
MNT Use FQCN for PHP translations

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,44 +1,88 @@
 en:
-  LinkField:
-    ANCHOR_DESCRIPTION: 'Do not prepend "#". Anchor suggestions will be displayed once the linked page is attached.'
-    ANCHOR_FIELD_TITLE: 'Anchor'
+  SilverStripe\LinkField\Controllers\LinkFieldController:
     BAD_DATA: 'Bad data'
     CREATE_LINK: 'Create link'
-    DATA_HAS_NO_TYPEKEY: '"{class}": $data does not have a typeKey.'
     EMPTY_DATA: 'Empty data'
-    EXTERNAL_URL_FIELD: 'External url'
-    EMAIL_FIELD: 'Email address'
-    FILE_FIELD: 'File'
-    INVALID_DATA_TO_ARRAY: '"{class}": Could not convert $data to an array.'
-    INVALID_ID': 'Invalid ID'
-    INVALID_JSON: '"{class}": Decoding json string failred with "{error}"'
+    INVALID_ID: 'Invalid ID'
+    INVALID_OWNER: 'Invalid Owner'
+    INVALID_OWNER_CLASS: 'Invalid ownerClass'
+    INVALID_OWNER_ID: 'Invalid ownerID'
+    INVALID_OWNER_RELATION: 'Invalid ownerRelation'
     INVALID_TOKEN: 'Invalid CSRF token'
     INVALID_TYPEKEY: 'Invalid typeKey'
-    INVALID_TYPENAME: '"{class}": {typename} is not a valid link type'
-    KEYS_ARE_NOT_ARRAY: 'If `keys` is provdied, it must be an array'
-    LINK_TYPE_TITLE: 'Link Type'
-    LINK_FIELD_TITLE: 'Title'
-    NO_CLASSNAME: '"{class}": All types should reference a valid classname'
-    NOT_REGISTERED_LINKTYPE: '"{class}": "{typekey}" is not a registered Link Type.'
-    NOTHING_TO_PROCESS: "Nothing to process for `{table}`\r\n"
-    OPEN_IN_NEW_TITLE: 'Open in new window?'
-    PAGE_FIELD_TITLE: 'Page'
-    PHONE_FIELD: 'Phone'
-    PROCESSING_TABLE: "Processing `{table}`\r\n"
-    QUERY_FIELD_TITLE: 'Query string'
-    QUERY_STRING_DESCRIPTION: 'Do not prepend "?". EG: "option1=value&option2=value2"'
-    RECORDS_INSERTED: "{numrecords} records inserted, finished processing `{table}`\r\n"
-    TITLE_DESCRIPTION: 'Auto generated from Page title if left blank'
-    UNAUTHORIZED: 'Unauthorized'
+    MENUTITLE: SilverStripe\LinkField\Controllers\LinkFieldController
+    UNAUTHORIZED: Unauthorized
     UPDATE_LINK: 'Update link'
-    VERSIONED_STATUS_MISMATCH: 'Linkable and LinkField do not have matching Versioned applications. Make sure that both are either un-Versioned or Versioned'
-  SilverStripe\LinkField\Models\Link:
-    LINK_FIELD_TITLE_DESCRIPTION: 'If left blank, an appropriate default title will be used on the front-end'
-    MISSING_DEFAULT_TITLE: 'No link provided'
-  SilverStripe\LinkField\Models\SiteTreeLink:
-    MISSING_DEFAULT_TITLE: 'Page missing'
-  SilverStripe\LinkField\Models\FileLink:
-    MISSING_DEFAULT_TITLE: 'File missing'
   SilverStripe\LinkField\Form\Traits\AllowedLinkClassesTrait:
     INVALID_TYPECLASS: '"{class}": {typeclass} is not a valid Link Type'
     INVALID_TYPECLASS_EMPTY: '"{class}": Allowed types cannot be empty'
+  SilverStripe\LinkField\Models\EmailLink:
+    EMAIL_FIELD: 'Email address'
+    PLURALNAME: 'Email Links'
+    PLURALS:
+      one: 'An Email Link'
+      other: '{count} Email Links'
+    SINGULARNAME: 'Email Link'
+    db_Email: Email
+  SilverStripe\LinkField\Models\ExternalLink:
+    EXTERNAL_URL_FIELD: 'External url'
+    PLURALNAME: 'External Links'
+    PLURALS:
+      one: 'An External Link'
+      other: '{count} External Links'
+    SINGULARNAME: 'External Link'
+    db_ExternalUrl: 'External url'
+  SilverStripe\LinkField\Models\FileLink:
+    CANNOT_VIEW_FILE: 'Cannot view file'
+    FILE_DOES_NOT_EXIST: 'File does not exist'
+    FILE_FIELD: File
+    MISSING_DEFAULT_TITLE: 'File missing'
+    PLURALNAME: 'File Links'
+    PLURALS:
+      one: 'A File Link'
+      other: '{count} File Links'
+    SINGULARNAME: 'File Link'
+    has_one_File: File
+  SilverStripe\LinkField\Models\Link:
+    LINK_FIELD_TITLE: Title
+    LINK_FIELD_TITLE_DESCRIPTION: 'If left blank, an appropriate default title will be used on the front-end'
+    LINK_TYPE_TITLE: 'Link Type'
+    MISSING_DEFAULT_TITLE: 'No link provided'
+    OPEN_IN_NEW_TITLE: 'Open in new window?'
+    PLURALNAME: Links
+    PLURALS:
+      one: 'A Link'
+      other: '{count} Links'
+    SINGULARNAME: Link
+    db_OpenInNew: 'Open in new'
+    db_Title: Title
+    db_Version: Version
+    has_one_Owner: Owner
+  SilverStripe\LinkField\Models\PhoneLink:
+    PHONE_FIELD: Phone
+    PLURALNAME: 'Phone Links'
+    PLURALS:
+      one: 'A Phone Link'
+      other: '{count} Phone Links'
+    SINGULARNAME: 'Phone Link'
+    db_Phone: Phone
+  SilverStripe\LinkField\Models\SiteTreeLink:
+    ANCHOR_DESCRIPTION: 'Do not prepend "#". Anchor suggestions will be displayed once the linked page is attached.'
+    ANCHOR_FIELD_TITLE: Anchor
+    CANNOT_VIEW_PAGE: 'Cannot view page'
+    MISSING_DEFAULT_TITLE: 'Page missing'
+    PAGE_DOES_NOT_EXIST: 'Page does not exist'
+    PAGE_FIELD_TITLE: Page
+    PLURALNAME: 'Site Tree Links'
+    PLURALS:
+      one: 'A Site Tree Link'
+      other: '{count} Site Tree Links'
+    QUERY_FIELD_TITLE: 'Query string'
+    QUERY_STRING_DESCRIPTION: 'Do not prepend "?". EG: "option1=value&option2=value2"'
+    SINGULARNAME: 'Site Tree Link'
+    TITLE_DESCRIPTION: 'Auto generated from Page title if left blank'
+    db_Anchor: Anchor
+    db_QueryString: 'Query string'
+    has_one_Page: Page
+  SilverStripe\LinkField\Tasks\LinkableMigrationTask:
+    VERSIONED_STATUS_MISMATCH: 'Linkable and LinkField do not have matching Versioned applications. Make sure that both are either un-Versioned or Versioned'

--- a/src/Controllers/LinkFieldController.php
+++ b/src/Controllers/LinkFieldController.php
@@ -67,17 +67,17 @@ class LinkFieldController extends LeftAndMain
         if ($id) {
             $link = Link::get()->byID($id);
             if (!$link) {
-                $this->jsonError(404, _t('LinkField.INVALID_ID', 'Invalid ID'));
+                $this->jsonError(404, _t(__CLASS__ . '.INVALID_ID', 'Invalid ID'));
             }
             $operation = 'edit';
             if (!$link->canView()) {
-                $this->jsonError(403, _t('LinkField.UNAUTHORIZED', 'Unauthorized'));
+                $this->jsonError(403, _t(__CLASS__ . '.UNAUTHORIZED', 'Unauthorized'));
             }
         } else {
             $typeKey = $this->typeKeyFromRequest();
             $link = LinkTypeService::create()->byKey($typeKey);
             if (!$link) {
-                $this->jsonError(404, _t('LinkField.INVALID_TYPEKEY', 'Invalid typeKey'));
+                $this->jsonError(404, _t(__CLASS__ . '.INVALID_TYPEKEY', 'Invalid typeKey'));
             }
             $operation = 'create';
         }
@@ -110,7 +110,7 @@ class LinkFieldController extends LeftAndMain
     private function getLinkData(Link $link): array
     {
         if (!$link->canView()) {
-            $this->jsonError(403, _t('LinkField.UNAUTHORIZED', 'Unauthorized'));
+            $this->jsonError(403, _t(__CLASS__ . '.UNAUTHORIZED', 'Unauthorized'));
         }
         $data = $link->jsonSerialize();
         $data['canDelete'] = $link->canDelete();
@@ -127,11 +127,11 @@ class LinkFieldController extends LeftAndMain
     {
         $link = $this->linkFromRequest();
         if (!$link->canDelete()) {
-            $this->jsonError(403, _t('LinkField.UNAUTHORIZED', 'Unauthorized'));
+            $this->jsonError(403, _t(__CLASS__ . '.UNAUTHORIZED', 'Unauthorized'));
         }
         // Check security token on destructive operation
         if (!SecurityToken::inst()->checkRequest($this->getRequest())) {
-            $this->jsonError(400, _t('LinkField.INVALID_TOKEN', 'Invalid CSRF token'));
+            $this->jsonError(400, _t(__CLASS__ . '.INVALID_TOKEN', 'Invalid CSRF token'));
         }
         // delete() will also delete any published version immediately
         $link->delete();
@@ -167,7 +167,7 @@ class LinkFieldController extends LeftAndMain
     public function save(array $data, Form $form): HTTPResponse
     {
         if (empty($data)) {
-            $this->jsonError(400, _t('LinkField.EMPTY_DATA', 'Empty data'));
+            $this->jsonError(400, _t(__CLASS__ . '.EMPTY_DATA', 'Empty data'));
         }
 
         /** @var Link $link */
@@ -177,10 +177,10 @@ class LinkFieldController extends LeftAndMain
             $operation = 'edit';
             $link = Link::get()->byID($id);
             if (!$link) {
-                $this->jsonErorr(404, _t('LinkField.INVALID_ID', 'Invalid ID'));
+                $this->jsonErorr(404, _t(__CLASS__ . '.INVALID_ID', 'Invalid ID'));
             }
             if (!$link->canEdit()) {
-                $this->jsonError(403, _t('LinkField.UNAUTHORIZED', 'Unauthorized'));
+                $this->jsonError(403, _t(__CLASS__ . '.UNAUTHORIZED', 'Unauthorized'));
             }
         } else {
             // Creating a new Link
@@ -188,17 +188,17 @@ class LinkFieldController extends LeftAndMain
             $typeKey = $this->typeKeyFromRequest();
             $className = LinkTypeService::create()->byKey($typeKey) ?? '';
             if (!$className) {
-                $this->jsonError(404, _t('LinkField.INVALID_TYPEKEY', 'Invalid typeKey'));
+                $this->jsonError(404, _t(__CLASS__ . '.INVALID_TYPEKEY', 'Invalid typeKey'));
             }
             $link = $className::create();
             if (!$link->canCreate()) {
-                $this->jsonError(403, _t('LinkField.UNAUTHORIZED', 'Unauthorized'));
+                $this->jsonError(403, _t(__CLASS__ . '.UNAUTHORIZED', 'Unauthorized'));
             }
         }
 
         // Ensure that ItemID url param matches the ID in the form data
         if (isset($data['ID']) && ((int) $data['ID'] !== $id)) {
-            $this->jsonError(400, _t('LinkField.BAD_DATA', 'Bad data'));
+            $this->jsonError(400, _t(__CLASS__ . '.BAD_DATA', 'Bad data'));
         }
 
         // Update DataObject from form data
@@ -285,8 +285,8 @@ class LinkFieldController extends LeftAndMain
 
         // Add save action button
         $title = $id
-                ? _t('LinkField.UPDATE_LINK', 'Update link')
-                : _t('LinkField.CREATE_LINK', 'Create link');
+                ? _t(__CLASS__ . '.UPDATE_LINK', 'Update link')
+                : _t(__CLASS__ . '.CREATE_LINK', 'Create link');
         $actions = FieldList::create([
             FormAction::create('save', $title)
                 ->setSchemaData(['data' => ['buttonStyle' => 'primary']]),
@@ -323,11 +323,11 @@ class LinkFieldController extends LeftAndMain
     {
         $itemID = $this->itemIDFromRequest();
         if (!$itemID) {
-            $this->jsonError(404, _t('LinkField.INVALID_ID', 'Invalid ID'));
+            $this->jsonError(404, _t(__CLASS__ . '.INVALID_ID', 'Invalid ID'));
         }
         $link = Link::get()->byID($itemID);
         if (!$link) {
-            $this->jsonError(404, _t('LinkField.INVALID_ID', 'Invalid ID'));
+            $this->jsonError(404, _t(__CLASS__ . '.INVALID_ID', 'Invalid ID'));
         }
         return $link;
     }
@@ -339,11 +339,11 @@ class LinkFieldController extends LeftAndMain
     {
         $itemIDs = $this->itemIDsFromRequest();
         if (empty($itemIDs)) {
-            $this->jsonError(404, _t('LinkField.INVALID_ID', 'Invalid ID'));
+            $this->jsonError(404, _t(__CLASS__ . '.INVALID_ID', 'Invalid ID'));
         }
         $links = Link::get()->byIDs($itemIDs);
         if (!$links->exists()) {
-            $this->jsonError(404, _t('LinkField.INVALID_ID', 'Invalid ID'));
+            $this->jsonError(404, _t(__CLASS__ . '.INVALID_ID', 'Invalid ID'));
         }
         return $links;
     }
@@ -356,7 +356,7 @@ class LinkFieldController extends LeftAndMain
         $request = $this->getRequest();
         $itemID = (string) $request->param('ItemID');
         if (!ctype_digit($itemID)) {
-            $this->jsonError(404, _t('LinkField.INVALID_ID', 'Invalid ID'));
+            $this->jsonError(404, _t(__CLASS__ . '.INVALID_ID', 'Invalid ID'));
         }
         return (int) $itemID;
     }
@@ -370,13 +370,13 @@ class LinkFieldController extends LeftAndMain
         $itemIDs = $request->getVar('itemIDs');
 
         if (!is_array($itemIDs)) {
-            $this->jsonError(404, _t('LinkField.INVALID_ID', 'Invalid ID'));
+            $this->jsonError(404, _t(__CLASS__ . '.INVALID_ID', 'Invalid ID'));
         }
 
         $idsAsInt = [];
         foreach ($itemIDs as $id) {
             if (!is_int($id) && !ctype_digit($id)) {
-                $this->jsonError(404, _t('LinkField.INVALID_ID', 'Invalid ID'));
+                $this->jsonError(404, _t(__CLASS__ . '.INVALID_ID', 'Invalid ID'));
             }
             $idsAsInt[] = (int) $id;
         }
@@ -392,7 +392,7 @@ class LinkFieldController extends LeftAndMain
         $request = $this->getRequest();
         $typeKey = (string) $request->getVar('typeKey');
         if (strlen($typeKey) === 0 || !preg_match('#^[a-z\-]+$#', $typeKey)) {
-            $this->jsonError(404, _t('LinkField.INVALID_TYPEKEY', 'Invalid typeKey'));
+            $this->jsonError(404, _t(__CLASS__ . '.INVALID_TYPEKEY', 'Invalid typeKey'));
         }
         return $typeKey;
     }
@@ -406,11 +406,11 @@ class LinkFieldController extends LeftAndMain
         $request = $this->getRequest();
         $ownerID = (int) ($request->getVar('ownerID') ?: $request->postVar('OwnerID'));
         if ($ownerID === 0) {
-            $this->jsonError(404, _t('LinkField.INVALID_OWNER_ID', 'Invalid ownerID'));
+            $this->jsonError(404, _t(__CLASS__ . '.INVALID_OWNER_ID', 'Invalid ownerID'));
         }
         $ownerClass = $request->getVar('ownerClass') ?: $request->postVar('OwnerClass');
         if (!is_a($ownerClass, DataObject::class, true)) {
-            $this->jsonError(404, _t('LinkField.INVALID_OWNER_CLASS', 'Invalid ownerClass'));
+            $this->jsonError(404, _t(__CLASS__ . '.INVALID_OWNER_CLASS', 'Invalid ownerClass'));
         }
         $ownerRelation = $this->ownerRelationFromRequest();
         /** @var DataObject $obj */
@@ -435,7 +435,7 @@ class LinkFieldController extends LeftAndMain
                 return $owner;
             }
         }
-        $this->jsonError(404, _t('LinkField.INVALID_OWNER', 'Invalid Owner'));
+        $this->jsonError(404, _t(__CLASS__ . '.INVALID_OWNER', 'Invalid Owner'));
     }
 
     /**
@@ -447,7 +447,7 @@ class LinkFieldController extends LeftAndMain
         $request = $this->getRequest();
         $ownerRelation = $request->getVar('ownerRelation') ?: $request->postVar('OwnerRelation');
         if (!$ownerRelation) {
-            $this->jsonError(404, _t('LinkField.INVALID_OWNER_RELATION', 'Invalid ownerRelation'));
+            $this->jsonError(404, _t(__CLASS__ . '.INVALID_OWNER_RELATION', 'Invalid ownerRelation'));
         }
         return $ownerRelation;
     }

--- a/src/Form/Traits/AllowedLinkClassesTrait.php
+++ b/src/Form/Traits/AllowedLinkClassesTrait.php
@@ -46,7 +46,7 @@ trait AllowedLinkClassesTrait
         if (empty($types)) {
             throw new InvalidArgumentException(
                 _t(
-                    __CLASS__ . '.INVALID_TYPECLASS_EMPTY',
+                    __TRAIT__ . '.INVALID_TYPECLASS_EMPTY',
                     '"{class}": Allowed types cannot be empty',
                     ['class' => static::class],
                 ),
@@ -60,7 +60,7 @@ trait AllowedLinkClassesTrait
             } else {
                 throw new InvalidArgumentException(
                     _t(
-                        __CLASS__ . '.INVALID_TYPECLASS',
+                        __TRAIT__ . '.INVALID_TYPECLASS',
                         '"{class}": {typeclass} is not a valid Link Type',
                         ['class' => static::class, 'typeclass' => $type],
                         sprintf(

--- a/src/Models/EmailLink.php
+++ b/src/Models/EmailLink.php
@@ -23,7 +23,7 @@ class EmailLink extends Link
         $this->beforeUpdateCMSFields(function (FieldList $fields) {
             $fields->replaceField('Email', EmailField::create(
                 'Email',
-                _t('LinkField.EMAIL_FIELD', 'Email address'),
+                _t(__CLASS__ . '.EMAIL_FIELD', 'Email address'),
             ));
         });
         return parent::getCMSFields();

--- a/src/Models/ExternalLink.php
+++ b/src/Models/ExternalLink.php
@@ -21,7 +21,7 @@ class ExternalLink extends Link
     {
         $this->beforeUpdateCMSFields(function (FieldList $fields) {
             $linkField = $fields->dataFieldByName('ExternalUrl');
-            $linkField->setTitle(_t('LinkField.EXTERNAL_URL_FIELD', 'External url'));
+            $linkField->setTitle(_t(__CLASS__ . '.EXTERNAL_URL_FIELD', 'External url'));
         });
         return parent::getCMSFields();
     }

--- a/src/Models/FileLink.php
+++ b/src/Models/FileLink.php
@@ -23,7 +23,7 @@ class FileLink extends Link
     {
         $this->beforeUpdateCMSFields(function (FieldList $fields) {
             $linkField = $fields->dataFieldByName('File');
-            $linkField->setTitle(_t('LinkField.FILE_FIELD', 'File'));
+            $linkField->setTitle(_t(__CLASS__ . '.FILE_FIELD', 'File'));
         });
         return parent::getCMSFields();
     }

--- a/src/Models/Link.php
+++ b/src/Models/Link.php
@@ -82,14 +82,14 @@ class Link extends DataObject
             $linkTypes = $this->getLinkTypes();
 
             $titleField = $fields->dataFieldByName('Title');
-            $titleField->setTitle(_t('LinkField.LINK_FIELD_TITLE', 'Title'));
+            $titleField->setTitle(_t(__CLASS__ . '.LINK_FIELD_TITLE', 'Title'));
             $titleField->setDescription(_t(
                 self::class . '.LINK_FIELD_TITLE_DESCRIPTION',
                 'If left blank, an appropriate default title will be used on the front-end',
             ));
 
             $openInNewField = $fields->dataFieldByName('OpenInNew');
-            $openInNewField->setTitle(_t('LinkField.OPEN_IN_NEW_TITLE', 'Open in new window?'));
+            $openInNewField->setTitle(_t(__CLASS__ . '.OPEN_IN_NEW_TITLE', 'Open in new window?'));
 
             if (static::class === self::class) {
                 // Add a link type selection field for generic links
@@ -98,7 +98,7 @@ class Link extends DataObject
                     [
                         $linkTypeField = DropdownField::create(
                             'LinkType',
-                            _t('LinkField.LINK_TYPE_TITLE', 'Link Type'),
+                            _t(__CLASS__ . '.LINK_TYPE_TITLE', 'Link Type'),
                             $linkTypes
                         ),
                     ],
@@ -160,7 +160,7 @@ class Link extends DataObject
             if (json_last_error() !== JSON_ERROR_NONE) {
                 throw new InvalidArgumentException(
                     _t(
-                        'LinkField.INVALID_JSON',
+                        __CLASS__ . '.INVALID_JSON',
                         '"{class}": Decoding json string failred with "{error}"',
                         [
                             'class' => static::class,
@@ -181,7 +181,7 @@ class Link extends DataObject
         if (!is_array($data)) {
             throw new InvalidArgumentException(
                 _t(
-                    'LinkField.INVALID_DATA_TO_ARRAY',
+                    __CLASS__ . '.INVALID_DATA_TO_ARRAY',
                     '"{class}": Could not convert $data to an array.',
                     ['class' => static::class],
                     sprintf('%s: Could not convert $data to an array.', static::class),
@@ -194,7 +194,7 @@ class Link extends DataObject
         if (!$typeKey) {
             throw new InvalidArgumentException(
                 _t(
-                    'LinkField.DATA_HAS_NO_TYPEKEY',
+                    __CLASS__ . '.DATA_HAS_NO_TYPEKEY',
                     '"{class}": $data does not have a typeKey.',
                     ['class' => static::class],
                     sprintf('%s: $data does not have a typeKey.', static::class),
@@ -207,7 +207,7 @@ class Link extends DataObject
         if (!$type) {
             throw new InvalidArgumentException(
                 _t(
-                    'LinkField.NOT_REGISTERED_LINKTYPE',
+                    __CLASS__ . '.NOT_REGISTERED_LINKTYPE',
                     '"{class}": "{typekey}" is not a registered Link Type.',
                     [
                         'class' => static::class,

--- a/src/Models/PhoneLink.php
+++ b/src/Models/PhoneLink.php
@@ -19,7 +19,7 @@ class PhoneLink extends Link
     {
         $this->beforeUpdateCMSFields(function (FieldList $fields) {
             $linkField = $fields->dataFieldByName('Phone');
-            $linkField->setTitle(_t('LinkField.PHONE_FIELD', 'Phone'));
+            $linkField->setTitle(_t(__CLASS__ . '.PHONE_FIELD', 'Phone'));
         });
         return parent::getCMSFields();
     }

--- a/src/Models/SiteTreeLink.php
+++ b/src/Models/SiteTreeLink.php
@@ -55,7 +55,7 @@ class SiteTreeLink extends Link
             $titleField = $fields->dataFieldByName('Title');
             $titleField?->setDescription(
                 _t(
-                    'LinkField.TITLE_DESCRIPTION',
+                    __CLASS__ . '.TITLE_DESCRIPTION',
                     'Auto generated from Page title if left blank',
                 ),
             );
@@ -64,7 +64,7 @@ class SiteTreeLink extends Link
                 'Title',
                 TreeDropdownField::create(
                     'PageID',
-                    _t('LinkField.PAGE_FIELD_TITLE', 'Page'),
+                    _t(__CLASS__ . '.PAGE_FIELD_TITLE', 'Page'),
                     SiteTree::class,
                     'ID',
                     'TreeTitle'
@@ -75,13 +75,13 @@ class SiteTreeLink extends Link
                 'PageID',
                 $queryStringField = TextField::create(
                     'QueryString',
-                    _t('LinkField.QUERY_FIELD_TITLE', 'Query string'),
+                    _t(__CLASS__ . '.QUERY_FIELD_TITLE', 'Query string'),
                 )
             );
 
             $queryStringField->setDescription(
                 _t(
-                    'LinkField.QUERY_STRING_DESCRIPTION',
+                    __CLASS__ . '.QUERY_STRING_DESCRIPTION',
                     'Do not prepend "?". EG: "option1=value&option2=value2"',
                 ),
             );
@@ -90,13 +90,13 @@ class SiteTreeLink extends Link
                 'QueryString',
                 $anchorField = AnchorSelectorField::create(
                     'Anchor',
-                    _t('LinkField.ANCHOR_FIELD_TITLE', 'Anchor')
+                    _t(__CLASS__ . '.ANCHOR_FIELD_TITLE', 'Anchor')
                 )
             );
 
             $anchorField->setDescription(
                 _t(
-                    'LinkField.ANCHOR_DESCRIPTION',
+                    __CLASS__ . '.ANCHOR_DESCRIPTION',
                     'Do not prepend "#". Anchor suggestions will be displayed once the linked page is attached.',
                 ),
             );

--- a/src/Tasks/LinkableMigrationTask.php
+++ b/src/Tasks/LinkableMigrationTask.php
@@ -172,7 +172,7 @@ class LinkableMigrationTask extends BuildTask
         if (!$this->versionedStatusMatches()) {
             throw new Exception(
                 _t(
-                    'LinkField.VERSIONED_STATUS_MISMATCH',
+                    __CLASS__ . '.VERSIONED_STATUS_MISMATCH',
                     'Linkable and LinkField do not have matching Versioned applications. Make sure that both are'
                     . ' either un-Versioned or Versioned'
                 ),
@@ -203,7 +203,7 @@ class LinkableMigrationTask extends BuildTask
             // Nothing to see here
             if ($linkableResults->numRecords() === 0) {
                 echo _t(
-                    'LinkField.NOTHING_TO_PROCESS',
+                    __CLASS__ . '.NOTHING_TO_PROCESS',
                     "Nothing to process for `{table}`\r\n",
                     ['table' => $table],
                     sprintf("Nothing to process for `%s`\r\n", $table)
@@ -213,7 +213,7 @@ class LinkableMigrationTask extends BuildTask
             }
 
             echo _t(
-                'LinkField.PROCESSING_TABLE',
+                __CLASS__ . '.PROCESSING_TABLE',
                 "Processing `{table}`\r\n",
                 ['table' => $table],
                 sprintf("Processing `%s`\r\n", $table)
@@ -248,7 +248,7 @@ class LinkableMigrationTask extends BuildTask
             }
 
             echo _t(
-                'LinkField.RECORDS_INSERTED',
+                __CLASS__ . '.RECORDS_INSERTED',
                 "{numrecords} records inserted, finished processing `{table}`\r\n",
                 [
                     'numrecords' => $linkableResults->numRecords(),


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-linkfield/issues/140

JS short classname namespace remains as it's the standard used in other modules e.g. admin
