### PR TITLE
Fix RequiredFields validation

### DIFF
--- a/src/Form/LinkField.php
+++ b/src/Form/LinkField.php
@@ -6,11 +6,12 @@ use SilverStripe\Forms\FormField;
 use SilverStripe\LinkField\Models\Link;
 use SilverStripe\LinkField\Form\Traits\AllowedLinkClassesTrait;
 use SilverStripe\LinkField\Form\Traits\LinkFieldGetOwnerTrait;
+use SilverStripe\Forms\HasOneRelationFieldInterface;
 
 /**
  * Allows CMS users to edit a Link object.
  */
-class LinkField extends FormField
+class LinkField extends FormField implements HasOneRelationFieldInterface
 {
     use AllowedLinkClassesTrait;
     use LinkFieldGetOwnerTrait;

--- a/src/Form/Traits/LinkFieldGetOwnerTrait.php
+++ b/src/Form/Traits/LinkFieldGetOwnerTrait.php
@@ -27,8 +27,12 @@ trait LinkFieldGetOwnerTrait
         $relation = $this->getName();
         // Elemental content block
         if (class_exists(BaseElement::class) && is_a($owner, BaseElement::class)) {
+            // Remove namespaces from inline editable blocks
+            // This will return an empty array for non-inline editable blocks (e.g. blocks in a gridfield)
             $arr = ElementalAreaController::removeNamespacesFromFields([$relation => ''], $owner->ID);
-            $relation = array_keys($arr)[0];
+            if (array_key_exists(0, $arr)) {
+                $relation = array_keys($arr)[0];
+            }
         }
         return [
             'ID' => $owner->ID,

--- a/src/Form/Traits/LinkFieldGetOwnerTrait.php
+++ b/src/Form/Traits/LinkFieldGetOwnerTrait.php
@@ -30,8 +30,8 @@ trait LinkFieldGetOwnerTrait
             // Remove namespaces from inline editable blocks
             // This will return an empty array for non-inline editable blocks (e.g. blocks in a gridfield)
             $arr = ElementalAreaController::removeNamespacesFromFields([$relation => ''], $owner->ID);
-            if (array_key_exists(0, $arr)) {
-                $relation = array_keys($arr)[0];
+            if (!empty($arr)) {
+                $relation = array_key_first($arr);
             }
         }
         return [


### PR DESCRIPTION
Two PR fixes two things in seperarte PRs, so do not squash merge
1. Fixing non-inline editing of elements which was totally busted `private static bool $inline_editable = false;` on the content block
2. Adds the new HasOneRelationFieldInterface to LinkField, which means that it can be used by the RequiredFields validator 

Requires https://github.com/silverstripe/silverstripe-framework/pull/11119 to be merged first