### PR TITLE
ENH Rename and move Title field

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,26 @@ class MyCustomLink extends Link
 
 Custom links can have validation set using standard [model validation](https://docs.silverstripe.org/en/5/developer_guides/forms/validation/#model-validation).
 
+## Migration from LinkField v3 to v4
+
+The `Title` DB field has been renamed to `LinkText`
+
+You can manually rename this column in your database with the following code:
+
+```php
+// app/_config.php
+use SilverStripe\LinkField\Models\Link;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+
+// Only run this once
+// This will rename the `Title` database column to `LinkText` in all relevant tables
+$linkTable = DataObject::getSchema()->baseDataTable(Link::class);
+DB::get_conn()->getSchemaManager()->renameField($linkTable, 'Title', 'LinkText');
+```
+
+It's recommended to put this code in a `BuildTask` so that you can run it exactly once, and then remove that code in a future deployment.
+
 ## Migrating from Shae Dawson's Linkable module
 
 https://github.com/sheadawson/silverstripe-linkable

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -30,7 +30,7 @@ en:
     FILE_DOES_NOT_EXIST: 'File does not exist'
     FILE_FIELD: File
     LINKLABEL: 'Link to a file'
-    MISSING_DEFAULT_TITLE: 'File missing'
+    MISSING_DEFAULT_TITLE: '(File missing)'
     PLURALNAME: 'File Links'
     PLURALS:
       one: 'A File Link'
@@ -38,10 +38,10 @@ en:
     SINGULARNAME: 'File Link'
     has_one_File: File
   SilverStripe\LinkField\Models\Link:
-    LINK_FIELD_TITLE: Title
-    LINK_FIELD_TITLE_DESCRIPTION: 'If left blank, an appropriate default title will be used on the front-end'
+    LINK_TEXT_TITLE: 'Link text'
+    LINK_TEXT_TEXT_DESCRIPTION: 'If left blank, an appropriate default will be used on the front-end'
     LINK_TYPE_TITLE: 'Link Type'
-    MISSING_DEFAULT_TITLE: 'No link provided'
+    MISSING_DEFAULT_TITLE: '(No value provided)'
     OPEN_IN_NEW_TITLE: 'Open in new window?'
     PLURALNAME: Links
     PLURALS:
@@ -49,7 +49,7 @@ en:
       other: '{count} Links'
     SINGULARNAME: Link
     db_OpenInNew: 'Open in new'
-    db_Title: Title
+    db_LinkText: 'Link text'
     db_Version: Version
     has_one_Owner: Owner
   SilverStripe\LinkField\Models\PhoneLink:
@@ -66,7 +66,7 @@ en:
     ANCHOR_FIELD_TITLE: Anchor
     CANNOT_VIEW_PAGE: 'Cannot view page'
     LINKLABEL: 'Page on this site'
-    MISSING_DEFAULT_TITLE: 'Page missing'
+    MISSING_DEFAULT_TITLE: '(Page missing)'
     PAGE_DOES_NOT_EXIST: 'Page does not exist'
     PAGE_FIELD_TITLE: Page
     PLURALNAME: 'Site Tree Links'

--- a/src/Models/FileLink.php
+++ b/src/Models/FileLink.php
@@ -59,7 +59,7 @@ class FileLink extends Link
     {
         $file = $this->File();
         if (!$file->exists()) {
-            return _t(__CLASS__ . '.MISSING_DEFAULT_TITLE', 'File missing');
+            return _t(__CLASS__ . '.MISSING_DEFAULT_TITLE', '(File missing)');
         }
 
         return (string) $this->getDescription();

--- a/src/Models/SiteTreeLink.php
+++ b/src/Models/SiteTreeLink.php
@@ -10,6 +10,7 @@ use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\Forms\CompositeValidator;
 use SilverStripe\Forms\RequiredFields;
+use SilverStripe\Forms\Tip;
 
 /**
  * A link to a Page in the CMS
@@ -61,16 +62,14 @@ class SiteTreeLink extends Link
                 'QueryString',
             ]);
 
-            $titleField = $fields->dataFieldByName('Title');
-            $titleField?->setDescription(
-                _t(
-                    __CLASS__ . '.TITLE_DESCRIPTION',
-                    'Auto generated from Page title if left blank',
-                ),
-            );
+            $linkTextField = $fields->dataFieldByName('LinkText');
+            $linkTextField?->setTitleTip(new Tip(_t(
+                __CLASS__ . '.TITLE_DESCRIPTION',
+                'Auto generated from Page title if left blank',
+            )));
 
             $fields->insertAfter(
-                'Title',
+                'LinkText',
                 TreeDropdownField::create(
                     'PageID',
                     _t(__CLASS__ . '.PAGE_FIELD_TITLE', 'Page'),
@@ -130,10 +129,7 @@ class SiteTreeLink extends Link
     {
         $page = $this->Page();
         if (!$page->exists()) {
-            return _t(
-                static::class . '.MISSING_DEFAULT_TITLE',
-                'Page missing',
-            );
+            return _t(static::class . '.MISSING_DEFAULT_TITLE', '(Page missing)');
         }
         if (!$page->canView()) {
             return '';

--- a/src/Tasks/LinkableMigrationTask.php
+++ b/src/Tasks/LinkableMigrationTask.php
@@ -90,7 +90,7 @@ class LinkableMigrationTask extends BuildTask
         'ID' => 'ID',
         'LastEdited' => 'LastEdited',
         'Created' => 'Created',
-        'Title' => 'Title',
+        'Title' => 'LinkText',
         'OpenInNewWindow' => 'OpenInNew',
     ];
 

--- a/templates/SilverStripe/LinkField/Models/Link.ss
+++ b/templates/SilverStripe/LinkField/Models/Link.ss
@@ -1,3 +1,3 @@
 <% if $exists %>
-    <a href="$URL" <% if $OpenInNew %>target="_blank" rel="noopener noreferrer"<% end_if %>>$DisplayTitle</a>
+    <a href="$URL" <% if $OpenInNew %>target="_blank" rel="noopener noreferrer"<% end_if %>>$Title</a>
 <% end_if %>

--- a/tests/php/Controllers/LinkFieldControllerTest.php
+++ b/tests/php/Controllers/LinkFieldControllerTest.php
@@ -81,10 +81,10 @@ class LinkFieldControllerTest extends FunctionalTest
                 . "&ownerRelation=$ownerRelation";
             $this->assertSame($expectedAction, $formSchema['schema']['action']);
             // schema is nested and retains 'Root' and 'Main' tab hierarchy
-            $this->assertSame('Phone', $formSchema['schema']['fields'][0]['children'][0]['children'][1]['name']);
+            $this->assertSame('Phone', $formSchema['schema']['fields'][0]['children'][0]['children'][0]['name']);
             $this->assertSame('action_save', $formSchema['schema']['actions'][0]['name']);
             // state node is flattened, unlike schema node
-            $this->assertSame($expectedValue, $formSchema['state']['fields'][3]['value']);
+            $this->assertSame($expectedValue, $formSchema['state']['fields'][2]['value']);
             $this->assertFalse(array_key_exists('errors', $formSchema));
             if ($idType === 'new-record') {
                 $this->assertSame('OwnerID', $formSchema['state']['fields'][6]['name']);
@@ -224,10 +224,10 @@ class LinkFieldControllerTest extends FunctionalTest
                 . "&ownerRelation=$ownerRelation";
             $this->assertSame($expectedUrl, $formSchema['schema']['action']);
             // schema is nested and retains 'Root' and 'Main' tab hierarchy
-            $this->assertSame('Phone', $formSchema['schema']['fields'][0]['children'][0]['children'][1]['name']);
+            $this->assertSame('Phone', $formSchema['schema']['fields'][0]['children'][0]['children'][0]['name']);
             $this->assertSame('action_save', $formSchema['schema']['actions'][0]['name']);
             // state node is flattened, unlike schema node
-            $this->assertSame('9876543210', $formSchema['state']['fields'][3]['value']);
+            $this->assertSame('9876543210', $formSchema['state']['fields'][2]['value']);
             if ($fail) {
                 // Phone was note updated on PhoneLink dataobject
                 $link = TestPhoneLink::get()->byID($newID);
@@ -548,18 +548,18 @@ class LinkFieldControllerTest extends FunctionalTest
      * @dataProvider provideLinkSort
      */
     public function testLinkSort(
-        array $newTitleOrder,
+        array $newLinkTextOrder,
         string $fail,
         int $expectedCode,
-        array $expectedTitles
+        array $expectedLinkTexts
     ): void {
         TestPhoneLink::$fail = $fail;
         $url = "/admin/linkfield/sort";
         $newLinkIDs = [];
         $links = TestPhoneLink::get();
-        foreach ($newTitleOrder as $num) {
+        foreach ($newLinkTextOrder as $num) {
             foreach ($links as $link) {
-                if ($link->Title === "My phone link 0$num") {
+                if ($link->LinkText === "My phone link 0$num") {
                     $newLinkIDs[] = $link->ID;
                 }
             }
@@ -575,8 +575,8 @@ class LinkFieldControllerTest extends FunctionalTest
         $response = $this->post($url, null, $headers, null, $body);
         $this->assertSame($expectedCode, $response->getStatusCode());
         $this->assertSame(
-            $this->getExpectedTitles($expectedTitles),
-            TestPhoneLink::get()->filter(['OwnerRelation' => 'LinkList'])->column('Title')
+            $this->getExpectedLinkTexts($expectedLinkTexts),
+            TestPhoneLink::get()->filter(['OwnerRelation' => 'LinkList'])->column('LinkText')
         );
     }
 
@@ -584,51 +584,51 @@ class LinkFieldControllerTest extends FunctionalTest
     {
         return [
             'Success' => [
-                'newTitleOrder' => [4, 2, 3],
+                'newLinkTextOrder' => [4, 2, 3],
                 'fail' => '',
                 'expectedCode' => 204,
-                'expectedTitles' => [4, 2, 3],
+                'expectedLinkTexts' => [4, 2, 3],
             ],
             'Emtpy data' => [
-                'newTitleOrder' => [],
+                'newLinkTextOrder' => [],
                 'fail' => '',
                 'expectedCode' => 400,
-                'expectedTitles' => [2, 3, 4],
+                'expectedLinkTexts' => [2, 3, 4],
             ],
             'Fail can edit' => [
-                'newTitleOrder' => [4, 2, 3],
+                'newLinkTextOrder' => [4, 2, 3],
                 'fail' => 'can-edit',
                 'expectedCode' => 403,
-                'expectedTitles' => [2, 3, 4],
+                'expectedLinkTexts' => [2, 3, 4],
             ],
             'Fail object data' => [
-                'newTitleOrder' => [],
+                'newLinkTextOrder' => [],
                 'fail' => 'object-data',
                 'expectedCode' => 400,
-                'expectedTitles' => [2, 3, 4],
+                'expectedLinkTexts' => [2, 3, 4],
             ],
             'Fail csrf token' => [
-                'newTitleOrder' => [4, 2, 3],
+                'newLinkTextOrder' => [4, 2, 3],
                 'fail' => 'csrf-token',
                 'expectedCode' => 400,
-                'expectedTitles' => [2, 3, 4],
+                'expectedLinkTexts' => [2, 3, 4],
             ],
             'Mismatched owner' => [
-                'newTitleOrder' => [4, 1, 2],
+                'newLinkTextOrder' => [4, 1, 2],
                 'fail' => '',
                 'expectedCode' => 400,
-                'expectedTitles' => [2, 3, 4],
+                'expectedLinkTexts' => [2, 3, 4],
             ],
             'Mismatched owner relation' => [
-                'newTitleOrder' => [4, 5, 2],
+                'newLinkTextOrder' => [4, 5, 2],
                 'fail' => '',
                 'expectedCode' => 400,
-                'expectedTitles' => [2, 3, 4],
+                'expectedLinkTexts' => [2, 3, 4],
             ],
         ];
     }
 
-    private function getExpectedTitles(array $expected): array
+    private function getExpectedLinkTexts(array $expected): array
     {
         return array_map(function ($num) {
             return "My phone link 0$num";

--- a/tests/php/Controllers/LinkFieldControllerTest.yml
+++ b/tests/php/Controllers/LinkFieldControllerTest.yml
@@ -3,30 +3,30 @@ SilverStripe\LinkField\Tests\Models\LinkTest\LinkOwner:
   TestLinkOwner02:
 SilverStripe\LinkField\Tests\Controllers\LinkFieldControllerTest\TestPhoneLink:
   TestPhoneLink01:
-    Title: My phone link 01
+    LinkText: My phone link 01
     Phone: 0123456789
     Sort: 1
     # Link relation is manually joined in LinkFieldControllerTest::setup()
   TestPhoneLink02:
-    Title: My phone link 02
+    LinkText: My phone link 02
     Phone: 111222333
     Sort: 1
     Owner: =>SilverStripe\LinkField\Tests\Models\LinkTest\LinkOwner.TestLinkOwner02
     OwnerRelation: LinkList
   TestPhoneLink03:
-    Title: My phone link 03
+    LinkText: My phone link 03
     Phone: 321321321
     Sort: 2
     Owner: =>SilverStripe\LinkField\Tests\Models\LinkTest\LinkOwner.TestLinkOwner02
     OwnerRelation: LinkList
   TestPhoneLink04:
-    Title: My phone link 04
+    LinkText: My phone link 04
     Phone: 444444444
     Sort: 3
     Owner: =>SilverStripe\LinkField\Tests\Models\LinkTest\LinkOwner.TestLinkOwner02
     OwnerRelation: LinkList
   TestPhoneLink05:
-    Title: My phone link 05
+    LinkText: My phone link 05
     Phone: 555555555
     Sort: 1
     Owner: =>SilverStripe\LinkField\Tests\Models\LinkTest\LinkOwner.TestLinkOwner02

--- a/tests/php/Models/LinkTest.php
+++ b/tests/php/Models/LinkTest.php
@@ -81,24 +81,24 @@ class LinkTest extends SapphireTest
         /** @var SiteTreeLink $model */
         $model = $this->objFromFixture(SiteTreeLink::class, 'page-link-1');
 
-        $this->assertEquals('PageLink1', $model->Title, 'We expect to get a default Link title');
+        $this->assertEquals('PageLink1', $model->LinkText, 'We expect to get a default Link title');
 
         /** @var SiteTree $page */
         $page = $this->objFromFixture(SiteTree::class, 'page-1');
 
         $model->PageID = $page->ID;
-        $model->Title = null;
+        $model->LinkText = null;
         $model->write();
 
         // The actual Database Title field should still be null
-        $this->assertNull($model->getField('Title'));
-        $this->assertEquals(null, $model->Title, 'We expect that link does not have a title');
+        $this->assertNull($model->getField('LinkText'));
+        $this->assertEquals(null, $model->LinkText, 'We expect that link does not have a title');
 
         $customTitle = 'My custom title';
-        $model->Title = $customTitle;
+        $model->LinkText = $customTitle;
         $model->write();
 
-        $this->assertEquals($customTitle, $model->Title, 'We expect to get the custom title not page title');
+        $this->assertEquals($customTitle, $model->LinkText, 'We expect to get the custom title not page title');
     }
 
     /**
@@ -133,39 +133,25 @@ class LinkTest extends SapphireTest
     public function testGetVersionedState(): void
     {
         // Versioned Link
-        $link = Link::create(['Title' => 'abc']);
+        $link = Link::create(['LinkText' => 'abc']);
         $this->assertTrue(Link::has_extension(Versioned::class));
         $this->assertEquals('unsaved', $link->getVersionedState());
         $link->write();
         $this->assertEquals('draft', $link->getVersionedState());
         $link->publishSingle();
         $this->assertEquals('published', $link->getVersionedState());
-        $link->Title = 'def';
+        $link->LinkText = 'def';
         $link->write();
         $this->assertEquals('modified', $link->getVersionedState());
         // Unversioned Link
         Link::remove_extension(Versioned::class);
-        $link = Link::create(['Title' => '123']);
+        $link = Link::create(['LinkText' => '123']);
         $this->assertEquals('unsaved', $link->getVersionedState());
         $link->write();
         $this->assertEquals('unversioned', $link->getVersionedState());
     }
 
-    /**
-     * @param string $identifier
-     * @param string $class
-     * @param string $expected
-     * @return void
-     * @dataProvider linkUrlCasesDataProvider
-     */
-    public function testGetUrl(string $identifier, string $class, string $expected): void
-    {
-        /** @var Link $link */
-        $link = $this->objFromFixture($class, $identifier);
-        $this->assertSame($expected, $link->getURL(), 'We expect specific URL value');
-    }
-
-    public function linkUrlCasesDataProvider(): array
+    public function provideGetUrl(): array
     {
         return [
             'internal link / page only' => [
@@ -241,7 +227,21 @@ class LinkTest extends SapphireTest
         ];
     }
 
-    function linkDefaultTitleDataProvider(): array
+    /**
+     * @param string $identifier
+     * @param string $class
+     * @param string $expected
+     * @return void
+     * @dataProvider provideGetUrl
+     */
+    public function testGetUrl(string $identifier, string $class, string $expected): void
+    {
+        /** @var Link $link */
+        $link = $this->objFromFixture($class, $identifier);
+        $this->assertSame($expected, $link->getURL(), 'We expect specific URL value');
+    }
+
+    function provideDefaultLinkTitle(): array
     {
         return [
             'page link' => [
@@ -267,7 +267,7 @@ class LinkTest extends SapphireTest
             'file link' => [
                 'identifier' => 'file-link-no-image',
                 'class' => FileLink::class,
-                'expected' => 'File missing'
+                'expected' => '(File missing)'
             ],
             'page link with default title' => [
                 'identifier' => 'page-link-with-default-title',
@@ -277,7 +277,7 @@ class LinkTest extends SapphireTest
             'page link no page default title' => [
                 'identifier' => 'page-link-no-page-default-title',
                 'class' => SiteTreeLink::class,
-                'expected' => 'Page missing'
+                'expected' => '(Page missing)'
             ],
             'email link with default title' => [
                 'identifier' => 'email-link-with-default-title',
@@ -303,14 +303,14 @@ class LinkTest extends SapphireTest
     }
 
     /**
-     * @dataProvider linkDefaultTitleDataProvider
+     * @dataProvider provideDefaultLinkTitle
      */
     public function testDefaultLinkTitle(string $identifier, string $class, string $expected): void
     {
         /** @var Link $link */
         $link = $this->objFromFixture($class, $identifier);
 
-        $this->assertEquals($expected, $link->getDisplayTitle());
+        $this->assertEquals($expected, $link->getTitle());
     }
 
     public function provideOwner()

--- a/tests/php/Models/LinkTest.yml
+++ b/tests/php/Models/LinkTest.yml
@@ -10,30 +10,30 @@ SilverStripe\Assets\Image:
 
 SilverStripe\LinkField\Models\Link:
   link-1:
-    Title: 'Link1'
+    LinkText: 'Link1'
 
 SilverStripe\LinkField\Models\SiteTreeLink:
   page-link-1:
-    Title: 'PageLink1'
+    LinkText: 'PageLink1'
   page-link-page-only:
-    Title: 'PageLinkPageOnly'
+    LinkText: 'PageLinkPageOnly'
     Page: =>SilverStripe\CMS\Model\SiteTree.page-1
   page-link-anchor-only:
-    Title: 'PageLinkAnchorOnly'
+    LinkText: 'PageLinkAnchorOnly'
     Anchor: 'my-anchor'
   page-link-query-string-only:
-    Title: 'PageLinkQueryStringOnly'
+    LinkText: 'PageLinkQueryStringOnly'
     QueryString: 'param1=value1&param2=option2'
   page-link-with-anchor:
-    Title: 'PageLinkWithAnchor'
+    LinkText: 'PageLinkWithAnchor'
     Anchor: 'my-anchor'
     Page: =>SilverStripe\CMS\Model\SiteTree.page-1
   page-link-with-query-string:
-    Title: 'PageLinkWithQueryString'
+    LinkText: 'PageLinkWithQueryString'
     QueryString: 'param1=value1&param2=option2'
     Page: =>SilverStripe\CMS\Model\SiteTree.page-1
   page-link-with-query-string-and-anchor:
-    Title: 'PageLinkWithQueryStringAndAnchor'
+    LinkText: 'PageLinkWithQueryStringAndAnchor'
     QueryString: 'param1=value1&param2=option2'
     Anchor: 'my-anchor'
     Page: =>SilverStripe\CMS\Model\SiteTree.page-1
@@ -44,37 +44,37 @@ SilverStripe\LinkField\Models\SiteTreeLink:
 
 SilverStripe\LinkField\Models\EmailLink:
   email-link-with-email:
-    Title: 'EmailLinkWithEmail'
+    LinkText: 'EmailLinkWithEmail'
     Email: 'maxime@silverstripe.com'
   email-link-no-email:
-    Title: 'EmailLinkNoEmail'
+    LinkText: 'EmailLinkNoEmail'
   email-link-with-default-title:
     Email: 'maxime@silverstripe.com'
 
 SilverStripe\LinkField\Models\ExternalLink:
   external-link-with-url:
-    Title: 'ExternalLinkWithUrl'
+    LinkText: 'ExternalLinkWithUrl'
     ExternalUrl: 'https://google.com'
   external-link-no-url:
-    Title: 'ExternalLinkNoUrl'
+    LinkText: 'ExternalLinkNoUrl'
   external-link-with-default-title:
     ExternalUrl: 'https://google.com'
 
 SilverStripe\LinkField\Models\PhoneLink:
   phone-link-with-phone:
-    Title: 'PhoneLinkWithPhone'
+    LinkText: 'PhoneLinkWithPhone'
     Phone: '+64 4 978 7330'
   phone-link-no-phone:
-    Title: 'PhoneLinkNoPhone'
+    LinkText: 'PhoneLinkNoPhone'
   phone-link-with-default-title:
     Phone: '+64 4 978 7330'
 
 SilverStripe\LinkField\Models\FileLink:
   file-link-with-image:
-    Title: 'FileLinkWithImage'
+    LinkText: 'FileLinkWithImage'
     File: =>SilverStripe\Assets\Image.image-1
   file-link-no-image:
-    Title: null
+    LinkText: null
     File: =>SilverStripe\Assets\Image.image-2
     OpenInNew: true
   file-link-with-default-title:

--- a/tests/php/Models/SiteTreeLinkTest.php
+++ b/tests/php/Models/SiteTreeLinkTest.php
@@ -37,7 +37,7 @@ class SiteTreeLinkTest extends SapphireTest
     {
         // Page does not exist
         $link = SiteTreeLink::create();
-        $this->assertSame('Page missing', $link->getDefaultTitle());
+        $this->assertSame('(Page missing)', $link->getDefaultTitle());
         // Page exists
         $page = new TestSiteTreeCanView(['Title' => 'My test page']);
         $page->write();

--- a/tests/php/Traits/AllowedLinkClassesTraitTest.php
+++ b/tests/php/Traits/AllowedLinkClassesTraitTest.php
@@ -199,7 +199,7 @@ class AllowedLinkClassesTraitTest extends SapphireTest
         $this->assertFalse($json['testphone']['allowed']);
     }
 
-    public function typePropsDataProvider() : array
+    public function provideGetTypesProps() : array
     {
         return [
             'SiteTreeLink props' => [
@@ -254,7 +254,7 @@ class AllowedLinkClassesTraitTest extends SapphireTest
     }
 
     /**
-     * @dataProvider typePropsDataProvider
+     * @dataProvider provideGetTypesProps
      */
     public function testGetTypesProps(
         string $class,


### PR DESCRIPTION
I fixed a few issues at once because it made sense because they're very closely related

The general approach of this PR was to update PHP change 'Title' to 'LinkText', though JS was left completely alone and still uses 'title'

Also in the XHR request to get linkData, there is now always a populated 'Title' field returned that returns getTitle().

This means we'll never have a empty title field unless someone puts in custom code to have a blank default title in which case it'll still have the unclickable area, though that's such an edge case I don't think we need to worry about it, 

Issues
- https://github.com/silverstripe/silverstripe-linkfield/issues/179
- https://github.com/silverstripe/silverstripe-linkfield/issues/128
- https://github.com/silverstripe/silverstripe-linkfield/issues/186