### PR TITLE
ENH More standardisation

### DIFF
--- a/src/Form/AbstractLinkField.php
+++ b/src/Form/AbstractLinkField.php
@@ -80,7 +80,7 @@ abstract class AbstractLinkField extends FormField
             $typesList[$key] = [
                 'key' => $key,
                 'title' => $type->getMenuTitle(),
-                'handlerName' => $type->LinkTypeHandlerName(),
+                'handlerName' => $type->getLinkTypeHandlerName(),
                 'priority' => $class::config()->get('menu_priority'),
                 'icon' => $class::config()->get('icon'),
                 'allowed' => $allowed,

--- a/src/Models/EmailLink.php
+++ b/src/Models/EmailLink.php
@@ -36,6 +36,13 @@ class EmailLink extends Link
         return parent::getCMSFields();
     }
 
+    public function getCMSCompositeValidator(): CompositeValidator
+    {
+        $validator = parent::getCMSCompositeValidator();
+        $validator->addValidator(RequiredFields::create(['Email']));
+        return $validator;
+    }
+
     public function getDescription(): string
     {
         return $this->Email ?: '';
@@ -53,12 +60,5 @@ class EmailLink extends Link
     public function getMenuTitle(): string
     {
         return _t(__CLASS__ . '.LINKLABEL', 'Link to email address');
-    }
-
-    public function getCMSCompositeValidator(): CompositeValidator
-    {
-        $validator = parent::getCMSCompositeValidator();
-        $validator->addValidator(RequiredFields::create(['Email']));
-        return $validator;
     }
 }

--- a/src/Models/ExternalLink.php
+++ b/src/Models/ExternalLink.php
@@ -37,6 +37,13 @@ class ExternalLink extends Link
         return parent::getCMSFields();
     }
 
+    public function getCMSCompositeValidator(): CompositeValidator
+    {
+        $validator = parent::getCMSCompositeValidator();
+        $validator->addValidator(RequiredFields::create(['ExternalUrl']));
+        return $validator;
+    }
+
     public function getDescription(): string
     {
         return $this->ExternalUrl ?: '';
@@ -54,12 +61,5 @@ class ExternalLink extends Link
     public function getMenuTitle(): string
     {
         return _t(__CLASS__ . '.LINKLABEL', 'Link to external URL');
-    }
-
-    public function getCMSCompositeValidator(): CompositeValidator
-    {
-        $validator = parent::getCMSCompositeValidator();
-        $validator->addValidator(RequiredFields::create(['ExternalUrl']));
-        return $validator;
     }
 }

--- a/src/Models/FileLink.php
+++ b/src/Models/FileLink.php
@@ -34,6 +34,13 @@ class FileLink extends Link
         return parent::getCMSFields();
     }
 
+    public function getCMSCompositeValidator(): CompositeValidator
+    {
+        $validator = parent::getCMSCompositeValidator();
+        $validator->addValidator(RequiredFields::create(['File']));
+        return $validator;
+    }
+
     public function getDescription(): string
     {
         $file = $this->File();
@@ -52,16 +59,6 @@ class FileLink extends Link
         return $file->exists() ? (string) $file->getURL() : '';
     }
 
-    protected function getDefaultTitle(): string
-    {
-        $file = $this->File();
-        if (!$file?->exists()) {
-            return _t(__CLASS__ . '.MISSING_DEFAULT_TITLE', '(File missing)');
-        }
-
-        return (string) $this->getDescription();
-    }
-
     /**
      * The title that will be displayed in the dropdown
      * for selecting the link type to create.
@@ -71,10 +68,13 @@ class FileLink extends Link
         return _t(__CLASS__ . '.LINKLABEL', 'Link to a file');
     }
 
-    public function getCMSCompositeValidator(): CompositeValidator
+    protected function getDefaultTitle(): string
     {
-        $validator = parent::getCMSCompositeValidator();
-        $validator->addValidator(RequiredFields::create(['File']));
-        return $validator;
+        $file = $this->File();
+        if (!$file?->exists()) {
+            return _t(__CLASS__ . '.MISSING_DEFAULT_TITLE', '(File missing)');
+        }
+
+        return (string) $this->getDescription();
     }
 }

--- a/src/Models/FileLink.php
+++ b/src/Models/FileLink.php
@@ -52,10 +52,10 @@ class FileLink extends Link
         return $file->exists() ? (string) $file->getURL() : '';
     }
 
-    public function getDefaultTitle(): string
+    protected function getDefaultTitle(): string
     {
         $file = $this->File();
-        if (!$file->exists()) {
+        if (!$file?->exists()) {
             return _t(__CLASS__ . '.MISSING_DEFAULT_TITLE', '(File missing)');
         }
 

--- a/src/Models/PhoneLink.php
+++ b/src/Models/PhoneLink.php
@@ -31,6 +31,13 @@ class PhoneLink extends Link
         return parent::getCMSFields();
     }
 
+    public function getCMSCompositeValidator(): CompositeValidator
+    {
+        $validator = parent::getCMSCompositeValidator();
+        $validator->addValidator(RequiredFields::create(['Phone']));
+        return $validator;
+    }
+
     public function getDescription(): string
     {
         return $this->Phone ?: '';
@@ -48,12 +55,5 @@ class PhoneLink extends Link
     public function getMenuTitle(): string
     {
         return _t(__CLASS__ . '.LINKLABEL', 'Phone number');
-    }
-
-    public function getCMSCompositeValidator(): CompositeValidator
-    {
-        $validator = parent::getCMSCompositeValidator();
-        $validator->addValidator(RequiredFields::create(['Phone']));
-        return $validator;
     }
 }

--- a/src/Models/SiteTreeLink.php
+++ b/src/Models/SiteTreeLink.php
@@ -37,18 +37,6 @@ class SiteTreeLink extends Link
 
     private static $icon = 'font-icon-page';
 
-    public function getDescription(): string
-    {
-        $page = $this->Page();
-        if (!$page?->exists()) {
-            return _t(__CLASS__ . '.PAGE_DOES_NOT_EXIST', 'Page does not exist');
-        }
-        if (!$page->canView()) {
-            return _t(__CLASS__ . '.CANNOT_VIEW_PAGE', 'Cannot view page');
-        }
-        return $page->URLSegment ?? '';
-    }
-
     public function getCMSFields(): FieldList
     {
         $this->beforeUpdateCMSFields(function (FieldList $fields) {
@@ -110,6 +98,25 @@ class SiteTreeLink extends Link
         return parent::getCMSFields();
     }
 
+    public function getCMSCompositeValidator(): CompositeValidator
+    {
+        $validator = parent::getCMSCompositeValidator();
+        $validator->addValidator(RequiredFields::create(['PageID']));
+        return $validator;
+    }
+
+    public function getDescription(): string
+    {
+        $page = $this->Page();
+        if (!$page?->exists()) {
+            return _t(__CLASS__ . '.PAGE_DOES_NOT_EXIST', 'Page does not exist');
+        }
+        if (!$page->canView()) {
+            return _t(__CLASS__ . '.CANNOT_VIEW_PAGE', 'Cannot view page');
+        }
+        return $page->URLSegment ?? '';
+    }
+
     public function getURL(): string
     {
         $page = $this->Page();
@@ -122,6 +129,15 @@ class SiteTreeLink extends Link
         return Controller::join_links($url, $anchorSegment, $queryStringSegment);
     }
 
+    /**
+     * The title that will be displayed in the dropdown
+     * for selecting the link type to create.
+     */
+    public function getMenuTitle(): string
+    {
+        return _t(__CLASS__ . '.LINKLABEL', 'Page on this site');
+    }
+
     protected function getDefaultTitle(): string
     {
         $page = $this->Page();
@@ -132,21 +148,5 @@ class SiteTreeLink extends Link
             return '';
         }
         return $page->Title;
-    }
-
-    /**
-     * The title that will be displayed in the dropdown
-     * for selecting the link type to create.
-     */
-    public function getMenuTitle(): string
-    {
-        return _t(__CLASS__ . '.LINKLABEL', 'Page on this site');
-    }
-
-    public function getCMSCompositeValidator(): CompositeValidator
-    {
-        $validator = parent::getCMSCompositeValidator();
-        $validator->addValidator(RequiredFields::create(['PageID']));
-        return $validator;
     }
 }

--- a/src/Models/SiteTreeLink.php
+++ b/src/Models/SiteTreeLink.php
@@ -122,7 +122,7 @@ class SiteTreeLink extends Link
         return Controller::join_links($url, $anchorSegment, $queryStringSegment);
     }
 
-    public function getDefaultTitle(): string
+    protected function getDefaultTitle(): string
     {
         $page = $this->Page();
         if (!$page->exists()) {

--- a/tests/php/Models/LinkTest.php
+++ b/tests/php/Models/LinkTest.php
@@ -70,7 +70,7 @@ class LinkTest extends SapphireTest
     {
         $model = $this->objFromFixture(Link::class, 'link-1');
 
-        $this->assertEquals('FormBuilderModal', $model->LinkTypeHandlerName());
+        $this->assertEquals('FormBuilderModal', $model->getLinkTypeHandlerName());
     }
 
     /**

--- a/tests/php/Models/SiteTreeLinkTest.php
+++ b/tests/php/Models/SiteTreeLinkTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\LinkField\Tests\Models;
 
+use ReflectionMethod;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\LinkField\Models\SiteTreeLink;
 use SilverStripe\LinkField\Tests\Models\SiteTreeLinkTest\TestSiteTreeCanView;
@@ -17,7 +18,7 @@ class SiteTreeLinkTest extends SapphireTest
     public function testGetDescription(): void
     {
         // SiteTreeLink without a page
-        $link = SiteTreeLink::create();
+        $link = new SiteTreeLink();
         $this->assertSame('Page does not exist', $link->getDescription());
         // SiteTreeLink with a page though cannot view the page
         $page = new TestSiteTreeCannotView(['URLSegment' => 'test-a']);
@@ -35,14 +36,17 @@ class SiteTreeLinkTest extends SapphireTest
 
     public function testGetDefaultTitle(): void
     {
+        $reflectionGetDefaultTitle = new ReflectionMethod(SiteTreeLink::class, 'getDefaultTitle');
+        $reflectionGetDefaultTitle->setAccessible(true);
+
         // Page does not exist
-        $link = SiteTreeLink::create();
-        $this->assertSame('(Page missing)', $link->getDefaultTitle());
+        $link = new SiteTreeLink();
+        $this->assertSame('(Page missing)', $reflectionGetDefaultTitle->invoke($link));
         // Page exists
         $page = new TestSiteTreeCanView(['Title' => 'My test page']);
         $page->write();
         $link->Page = $page->ID;
         $link->write();
-        $this->assertSame('My test page', $link->getDefaultTitle());
+        $this->assertSame('My test page', $reflectionGetDefaultTitle->invoke($link));
     }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Two commits:
1. The bulk of the standardisation - removing some more unused code, adding a test, etc.
2. Just moving some methods around (and some very minor changes to phpdoc). I did this separately so it'll be easier to review the actual changes being made.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-linkfield/issues/78

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
