### PR TITLE
MNT Additional behat tests

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -15,7 +15,8 @@ default:
         - SilverStripe\Framework\Tests\Behaviour\CmsUiContext
         - SilverStripe\BehatExtension\Context\BasicContext
         - SilverStripe\BehatExtension\Context\LoginContext
-        - SilverStripe\BehatExtension\Context\FixtureContext:
+        - 
+          SilverStripe\BehatExtension\Context\FixtureContext:
             - '%paths.modules.linkfield%/tests/behat/features/files/'
 
   extensions:

--- a/tests/behat/features/accessibility-linkfield.feature
+++ b/tests/behat/features/accessibility-linkfield.feature
@@ -1,0 +1,138 @@
+@retry
+Feature: Accessibility Tests
+  As a content editor
+  I want to create and interact with LinkField using the keyboard
+
+  Background:
+    Given I add an extension "SilverStripe\FrameworkTest\LinkField\Extensions\LinkPageExtension" to the "Page" class
+    And I go to "/dev/build?flush"
+    And there are the following Page records
+    """
+    page-1:
+      Title: "Page 1"
+      URLSegment: 'page-1'
+    """
+    And there are the following SilverStripe\LinkField\Models\SiteTreeLink records
+    """
+    page-link-1:
+      OwnerID: 1
+      LinkText: 'Page Link 1'
+      QueryString: 'param1=value1&param2=option2'
+      Anchor: 'my-anchor'
+      Page: =>Page.page-1
+    """
+    And there are the following SilverStripe\LinkField\Models\EmailLink records
+    """
+    email-link:
+      LinkText: 'Email Link'
+      Email: 'maxime@silverstripe.com'
+    """
+    And there are the following SilverStripe\LinkField\Models\ExternalLink records
+    """
+    external-link:
+      LinkText: 'External Link'
+      ExternalUrl: 'https://google.com'
+    """
+    And there are the following Page records
+    """
+    link-page-1:
+      Title: 'Link Page'
+      URLSegment: 'link-page-1'
+      HasManyLinks:
+        - =>SilverStripe\LinkField\Models\SiteTreeLink.page-link-1
+        - =>SilverStripe\LinkField\Models\EmailLink.email-link
+        - =>SilverStripe\LinkField\Models\ExternalLink.external-link
+    """
+    And I go to "/dev/build?flush"
+    And the "group" "EDITOR" has permissions "Access to 'Pages' section"
+    And I am logged in as a member of "EDITOR" group
+    And I go to "/admin/pages"
+    And I should see "Link Page"
+    And I click on "Link Page" in the tree
+
+  Scenario: I can create and edit a LinkField using the keyboard
+    Given I should see the "#Form_EditForm_HasManyLinks" element
+    And I should see the "#Form_EditForm_HasOneLink" element
+
+    # Create SiteTreeLink in LinkField using keyboard
+
+    When I focus on the "[data-field-id='Form_EditForm_HasOneLink'] button" element
+    And I press the "Enter" key globally
+    Then the active element should be "[data-field-id='Form_EditForm_HasOneLink'] .dropdown-item:nth-of-type(1)"
+    When I press the "Enter" key globally
+    And I wait for 2 seconds
+    Then I should see "Page on this site" in the ".modal-header" element
+    And I wait for 2 seconds
+
+    # Test accessibility of the modal form
+
+    Then I type "About Us" in the active element "#Form_LinkForm_0_PageID"
+    And I press the "Enter" key globally
+    And I press the "Tab" key globally
+
+    Then I type "newquery=1" in the active element "[name='QueryString']"
+    And I press the "Tab" key globally
+
+    Then I type "new anchor" in the active element ".anchorselectorfield__input"
+    And I press the "Enter" key globally
+    And I press the "Tab" key globally
+    When I press the "Enter" key globally
+    Then I should see "Auto generated from Page title if left blank"
+    And I press the "Enter" key globally
+    And I press the "Tab" key globally
+
+    Then I type "New Page Link" in the active element "[name='LinkText']"
+    And I press the "Tab" key globally
+    Then the active element should be "[name='OpenInNew']"
+    And I press the "Space" key globally
+    And I press the "Tab" key globally
+    Then I press the "Enter" key globally
+    And I wait for 2 seconds
+
+    Then I should see "New Page Link" in the "[data-field-id='Form_EditForm_HasOneLink']" element
+    And I should see "about-us" in the "[data-field-id='Form_EditForm_HasOneLink'] .link-picker__url" element
+
+    # Test accessibility of the LinkField menu
+
+    Then I press the "Tab" key globally
+    And I press the "Tab" key globally
+    And I press the "Enter" key globally
+    And I should see "Page on this site" in the "[data-field-id='Form_EditForm_HasManyLinks'] .dropdown-menu.show" element
+    And I press the "Down" key globally
+    And I press the "Down" key globally
+    Then the active element should be "[data-field-id='Form_EditForm_HasManyLinks'] .dropdown-item:nth-of-type(3)"
+    And I press the "Enter" key globally
+    Then I should see "Link to external URL" in the ".modal-header" element
+    And I press the "Tab" key globally
+    Then I should see "External URL is required" in the ".modal-content" element
+    And I press the "Tab" key globally
+    And I press the "Tab" key globally
+    And I press the "Tab" key globally
+    And I press the "Tab" key globally
+    And the active element should be ".close"
+    And I press the "Enter" key globally
+    And I wait for 2 seconds
+
+    # Test accessibility of the LinkField keyboard sorting
+
+    Then I should see "Page Link 1" in the "[data-field-id='Form_EditForm_HasManyLinks'] .link-picker__link--is-first" element
+    And I should see "External Link" in the "[data-field-id='Form_EditForm_HasManyLinks'] .link-picker__link--is-last" element
+    When I press the "Tab" key globally
+    Then the active element should be "[data-field-id='Form_EditForm_HasManyLinks'] .link-picker__drag-handle"
+    Then I press the "Enter" key globally
+    And I press the "Down" key globally
+    And I press the "Down" key globally
+    And I press the "Enter" key globally
+    Then I should see "Email Link" in the "[data-field-id='Form_EditForm_HasManyLinks'] .link-picker__link--is-first" element
+    And I should see "External Link" in the "[data-field-id='Form_EditForm_HasManyLinks'] .link-picker__link:nth-of-type(2)" element
+    And I should see "Page Link 1" in the "[data-field-id='Form_EditForm_HasManyLinks'] .link-picker__link--is-last" element
+
+    # Test user can delete the link
+
+    Then I press the "Tab" key globally
+    And I press the "Tab" key globally
+    Then the active element should be "[data-field-id='Form_EditForm_HasManyLinks'] .link-picker__link:nth-of-type(3) .link-picker__delete"
+    And I press the "Enter" key and confirm the dialog
+    And I wait for 3 seconds
+    Then I should not see "Page Link 1" in the "[data-field-id='Form_EditForm_HasManyLinks']" element
+    And I press the "Enter" key globally


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

Additional Behat tests to test user interaction with LinField using the keyboard.
Tests check the ability to create links and sort using "drag and drop".

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
Not required

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-linkfield/issues/205

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
