### PR TITLE
DOC Fix docs links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ composer require silverstripe/linkfield
 
 ## Documentation
 
-See [the official documentation](https://userhelp.silverstripe.org/en/optional_features/linkfield)
+* [Developer documentation](https://docs.silverstripe.org/en/optional_features/linkfield)
+* [User help guide](https://userhelp.silverstripe.org/en/optional_features/linkfield)


### PR DESCRIPTION
Should link to both dev docs and user help.

Links obviously won't work until those docs are released in April.

## Issue
- https://github.com/silverstripe/silverstripe-linkfield/issues/235