### PR TITLE
NEW Add migration task from older versions of the module

### DIFF
--- a/docs/en/09_migrating/00_upgrading.md
+++ b/docs/en/09_migrating/00_upgrading.md
@@ -5,20 +5,119 @@ summary: A guide for migrating from older versions of silverstripe/linkfield
 
 # Upgrading from older versions
 
-The `Title` DB field has been renamed to `LinkText`
+> [!NOTE]
+> If your site is running Silverstripe CMS 4.x, update your constraint for `silverstripe/linkfield` to `^3.0.0-beta1` and upgrade to CMS 5 first.
+> There should be no additional steps required for upgrading from linkfield 2.x to linkfield 3.x.
+> Once you have finished upgrading to CMS 5, return to this guide and continue the linkfield upgrade.
 
-You can manually rename this column in your database with the following code:
+There are three major changes introduced in `silverstripe/linkfield` 4.0.0:
 
-```php
-// app/_config.php
-use SilverStripe\LinkField\Models\Link;
-use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\DB;
+1. The `Title` database field has been renamed to `LinkText`
+1. There is now a `has_one` relation on the [`Link`](api:SilverStripe\LinkField\Models\Link) class called `Owner` which must contain the record that owns the link.
+1. There is now a form field for managing `has_many` relations to link
 
-// Only run this once
-// This will rename the `Title` database column to `LinkText` in all relevant tables
-$linkTable = DataObject::getSchema()->baseDataTable(Link::class);
-DB::get_conn()->getSchemaManager()->renameField($linkTable, 'Title', 'LinkText');
-```
+This guide will help you update to the latest version of `silverstripe/linkfield` and run a task that will automatically update your data.
 
-It's recommended to put this code in a `BuildTask` so that you can run it exactly once, and then remove that code in a future deployment.
+> [!WARNING]
+> This guide does not provide an upgrade path for links which were stored using the legacy `DBLink` database field type.
+> If you have any links like that in your project, you will need to write your own migration script.
+
+## Setup
+
+1. Take a backup of your database
+1. Update your composer dependency for `silverstripe/linkfield` to `^4`
+
+    ```bash
+    composer require silverstripe/linkfield:^4
+    ```
+
+1. Update relations
+    - If the `has_one` relation for the record which owns the links (e.g. `Page`) has a corresponding `belongs_to` relation on the `Link` model (either added via an extension or YAML configuration), remove the `belongs_to` relation from the `Link` model.
+    - For any `has_many` relations to links on the record that owns the links (e.g. `Page`), update the dot notation to point to the `Owner` relation:
+
+        ```diff
+        private static array $has_many = [
+        -   'LinkListOne' => Link::class . '.FirstHasOne',
+        +   'LinkListOne' => Link::class . '.Owner',
+        -   'LinkListTwo' => Link::class . '.SecondHasOne',
+        +   'LinkListTwo' => Link::class . '.Owner',
+        ];
+        ```
+
+    - Remove the `has_one` relation on the relevant `Link` class which was storing the `has_many` relations.
+        - e.g. for the above, remove the `FirstHasOne` and `SecondHasOne` relations from the `Link` class. You may have applied these via an `Extension` class or via YAML configuration.
+    - If the models that have `has_one` or `has_many` relations to link don't already use `$owns` configuration for those relations, add that now. You may also want to set `$cascade_deletes` and `$cascade_duplicates` configuration. See [basic usage](../01_basic_usage.md) for more details.
+
+    > [!WARNING]
+    > `many_many` relations to `Link` are not supported. If you have any `many_many` relations to links you will need to migrate these to `has_many` relations yourself.
+
+## Customising the migration
+
+There are many extension hooks in the [`LinkFieldMigrationTask`](api:SilverStripe\LinkField\Tasks\LinkFieldMigrationTask) class which you can use to change its behaviour or add additional migration steps. We strongly recommend taking a look at the source code to see if your use case requires any customisations.
+
+Some scenarios where you may need customisations include:
+
+- You had applied the [`Versioned`](api:SilverStripe\Versioned\Versioned) extension to `Link` and want to prevent publishing links that should remain in draft.
+- You have a setup that allows moving links from one page to another, and want to ensure the correct `Owner` is set for old versions of the link record.
+- You have additional custom columns that need to be migrated, which the task doesn't know about.
+
+## Migrating
+
+For databases that support transactions, the full data migration is performed within a single transaction, and any errors in the migration will result in rolling back all changes. This means you can address whatever caused the error and then run the task again.
+
+> [!NOTE]
+> We strongly recommend running this task in a local development environment before trying it in production.
+> There may be edge cases that the migration task doesn't account for which need to be resolved.
+
+1. Prepare the task
+    - Enable the task:
+
+        ```yml
+        SilverStripe\LinkField\Tasks\LinkFieldMigrationTask:
+          is_enabled: true
+        ```
+
+    - Declare any `has_many` relations that need to be migrated:
+
+        ```yml
+        SilverStripe\LinkField\Tasks\LinkFieldMigrationTask:
+          # ...
+          has_many_links_data:
+            # The class where the has_many relation is declared
+            App\Model\MyClass:
+              # The name of the has_many relation
+              LinkListOne:
+                # The class where the old has_one relation was declared
+                # This will be either be Link or a Link subclass (not an extension applied to a Link class)
+                linkClass: 'SilverStripe\LinkField\Models\Link'
+                # The old name of the has_one relation on Link or a Link subclass
+                hasOne: 'MyOwner'
+        ```
+
+    - Declare any classes that may have `has_one` relations to `Link`, but which do not *own* the link. Classes declared here will include any subclasses.
+        For example if a custom link has a `has_many` relation to some class which does not own the link, declare that class here so it is not incorrectly identified as the owner of the link:
+
+        ```yml
+        SilverStripe\LinkField\Tasks\LinkFieldMigrationTask:
+          # ...
+          classes_that_are_not_link_owners:
+            - App\Model\SomeClass
+        ```
+
+1. Run dev/build and flush your cache (use the method you will be using the for next step - i.e. if you're running the task via the terminal, make sure to flush via the terminal)
+    - via the browser: `https://www.example.com/dev/build?flush=1`
+    - via a terminal: `sake dev/build flush=1`
+1. Run the task
+    - via the browser: `https://www.example.com/dev/tasks/linkfield-tov4-migration-task`
+    - via a terminal: `sake dev/tasks/linkfield-tov4-migration-task`
+1. If you have any `has_many` relations to `Link`, replace the `GridField` you're currently using the manage those links with a [`MultiLinkField`](api:SilverStripe\LinkField\Form\MultiLinkField). See [basic usage](../01_basic_usage.md) for details.
+
+The task performs the following steps:
+
+1. Migrates content in the `Title` column into the new `LinkText` column and removes the `Title` column from the database.
+1. Migrates any `has_many` relations to link which were declared in [`LinkFieldMigrationTask.has_many_links_data`](api:SilverStripe\LinkField\Tasks\LinkFieldMigrationTask->has_many_links_data) and removes the old `*ID` (and `*Class` for polymorphic relations) columns from the old `has_one` relations.
+1. Set the `Owner` relation for `has_one` relations to links.
+1. Publishes all links, unless you have removed the `Versioned` extension.
+1. Output a table with any links which are lacking the data required to generate a URL.
+    - You can skip this step by adding `?skipBrokenLinks=1` to the end of the URL: `https://www.example.com/dev/tasks/linkfield-tov4-migration-task?skipBrokenLinks=1`.
+    - If you're running the task in a terminal, you can add `skipBrokenLinks=1` as an argument: `sake dev/tasks/linkfield-tov4-migration-task skipBrokenLinks=1`.

--- a/src/Tasks/LinkFieldMigrationTask.php
+++ b/src/Tasks/LinkFieldMigrationTask.php
@@ -1,0 +1,690 @@
+<?php declare(strict_types=1);
+
+namespace SilverStripe\LinkField\Tasks;
+
+use LogicException;
+use RuntimeException;
+use SilverStripe\Assets\Shortcodes\FileLink as WYSIWYGFileLink;
+use SilverStripe\CMS\Model\SiteTreeLink as WYSIWYGSiteTreeLink;
+use SilverStripe\Control\Director;
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\BuildTask;
+use SilverStripe\Dev\Deprecation;
+use SilverStripe\LinkField\Models\EmailLink;
+use SilverStripe\LinkField\Models\ExternalLink;
+use SilverStripe\LinkField\Models\FileLink;
+use SilverStripe\LinkField\Models\Link;
+use SilverStripe\LinkField\Models\PhoneLink;
+use SilverStripe\LinkField\Models\SiteTreeLink;
+use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DataObjectSchema;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\Queries\SQLSelect;
+use SilverStripe\ORM\Queries\SQLUpdate;
+use SilverStripe\Versioned\ChangeSet;
+use SilverStripe\Versioned\ChangeSetItem;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * @deprecated 4.0.0 Will be removed without equivalent functionality.
+ */
+class LinkFieldMigrationTask extends BuildTask
+{
+    private static $segment = 'linkfield-tov4-migration-task';
+
+    protected $title = 'Linkfield v2/3 to v4 Migration Task';
+
+    protected $description = 'Migrate from silverstripe/linkfield v2 or v3 to v4';
+
+    /**
+     * Enable via YAML configuration if you need to run this task
+     */
+    private static ?bool $is_enabled = false;
+
+    /**
+     * Classes which should be skipped when finding owners of links.
+     * These classes and all of their subclasses will be skipped.
+     */
+    private static array $classes_that_are_not_link_owners = [
+        // Skip models that are used for internal tracking purposes and cannot own links
+        ChangeSet::class,
+        ChangeSetItem::class,
+        WYSIWYGFileLink::class,
+        WYSIWYGSiteTreeLink::class,
+    ];
+
+    /**
+     * List any has_many relations that should be migrated.
+     *
+     * Keys are the FQCN for the class where the has_many is declared.
+     * Values are an associative array of the Link class that held the has_one
+     * and the name of the old has_one.
+     *
+     * Example:
+     * <code>
+     * // SiteConfig had two has_many relationships,
+     * // one to Link.MyHasOne and another to ExternalLink.DifferentHasOne.
+     * SiteConfig::class => [
+     *   'LinksListOne' => [
+     *     'linkClass' => Link::class,
+     *     'hasOne' => 'MyHasOne',
+     *   ]
+     *   'LinksListTwo' => [
+     *     'linkClass' => ExternalLink::class,
+     *     'hasOne' => 'DifferentHasOne',
+     *   ]
+     * ]
+     * </code>
+     */
+    private static array $has_many_links_data = [];
+
+    /**
+     * in-memory cache of Link relational data so we don't keep slamming the filesystem cache
+     * when checking these relations in CLI
+     */
+    private array $linkRelationData = [];
+
+    public function __construct()
+    {
+        // Use withNoReplacement() because otherwise even viewing the dev/tasks list will trigger this warning.
+        Deprecation::withNoReplacement(
+            fn () => Deprecation::notice('4.0.0', 'Will be removed without equivalent functionality.', Deprecation::SCOPE_CLASS)
+        );
+        parent::__construct();
+    }
+
+    public function run($request): void
+    {
+        $db = DB::get_conn();
+        $baseTable = DataObject::getSchema()->baseDataTable(Link::class);
+
+        // If we don't need to migrate, exit early.
+        if (!$this->getNeedsMigration($baseTable)) {
+            $this->print('Cannot perform migration.');
+            return;
+        }
+
+        if (!$db->supportsTransactions()) {
+            $this->print('Database transactions are not supported for this database. Errors may result in a partially-migrated state.');
+        }
+
+        $db->withTransaction([$this, 'performMigration'], [$this, 'failedTransaction']);
+
+        if ($request->getVar('skipBrokenLinks')) {
+            $this->print('Skipping broken link check as requested.');
+        } else {
+            $this->checkForBrokenLinks();
+        }
+
+        $this->print('Done.');
+    }
+
+    /**
+     * Used in a callback if there is an error with the migration that causes a rolled back DB transaction
+     */
+    public function failedTransaction()
+    {
+        if (DB::get_conn()->supportsTransactions()) {
+            $this->print('There was an error with the migration. Rolling back.');
+        }
+    }
+
+    /**
+     * Perform the actual data migration and publish links as appropriate
+     */
+    public function performMigration()
+    {
+        // Migrate data
+        $this->migrateTitleColumn();
+        $this->migrateHasManyRelations();
+        $this->setOwnerForHasOneLinks();
+
+        $this->print('-----------------');
+        $this->print('Bulk data migration complete. All links should be correct (but unpublished) at this stage.');
+        $this->print('-----------------');
+
+        $this->publishLinks();
+
+        $this->print('-----------------');
+        $this->print('Migration completed successfully.');
+        $this->print('-----------------');
+    }
+
+    /**
+     * Check if we actually need to migrate anything, and if not give clear output as to why not.
+     */
+    private function getNeedsMigration(string $baseTable): bool
+    {
+        $needsMigration = false;
+        $needColumns = ['LinkText', 'Title'];
+        $baseDbColumns = array_keys(DB::field_list($baseTable));
+        $baseNeededColumns = array_intersect($needColumns, $baseDbColumns);
+
+        // If we have all of the requisite columns, we can proceed.
+        if ($baseNeededColumns === $needColumns) {
+            $needsMigration = true;
+            // Lets developers swap the true to a false if they know something we don't about their setup.
+            $this->extend('updateNeedsMigration', $needsMigration);
+            if (!$needsMigration) {
+                $this->print('Skipping migration due to project-level customisation.');
+            }
+            return $needsMigration;
+        }
+
+        // Lets developers swap the false to a true if they know something we don't about their setup.
+        $this->extend('updateNeedsMigration', $needsMigration);
+        if ($needsMigration) {
+            $this->print('Not skipping migration due to project-level customisation.');
+        }
+
+        // If we're missing anything, give clear output about what the situation is.
+        $missingColumns = array_diff($needColumns, $baseNeededColumns);
+        if (count($missingColumns) > 1) {
+            $this->print('Missing multiple columns in the database. This usually happens in new installations before dev/build.');
+            return $needsMigration;
+        }
+        $missingColumnKey = array_key_first($missingColumns);
+        switch ($missingColumns[$missingColumnKey]) {
+            case 'Title':
+                $this->print('Missing "Title" column in database. This usually means you have already run this task or do not need to migrate.');
+                break;
+            case 'LinkText':
+                $this->print('Missing "LinkText" column in database. This usually means you need to upgrade your silverstripe/linkfield dependency and run dev/build.');
+                break;
+            default:
+                // This should never happen, but better to throw an exception here than to assume nothing went wrong.
+                throw new LogicException("Got unexpected missing column '{$missingColumns[$missingColumnKey]}'.");
+        }
+        return $needsMigration;
+    }
+
+    /**
+     * Migrate the old Title column to the new LinkText column
+     */
+    private function migrateTitleColumn(): void
+    {
+        $this->extend('beforeMigrateTitleColumn');
+
+        // Migrate base Link table
+        $baseTable = DataObject::getSchema()->baseDataTable(Link::class);
+        $this->print("Migrating data in '$baseTable' table.");
+        $this->migrateColumn($baseTable, 'Title', 'LinkText');
+
+        // Migrate versioned Link tables
+        $needColumns = ['LinkText', 'Title'];
+        if (Link::has_extension(Versioned::class)) {
+            // Migrate `_Versions` and `_Live` tables
+            foreach (["{$baseTable}_Versions", "{$baseTable}_Live"] as $versionedTable) {
+                $versionedDbColumns = array_keys(DB::field_list($versionedTable));
+                // If we don't have both columns in the table, skip migrating this table
+                if (array_intersect($needColumns, $versionedDbColumns) !== $needColumns) {
+                    $this->print("Nothing to migrate in '$versionedTable' table.");
+                    continue;
+                }
+                $this->print("Migrating data in '$versionedTable' table.");
+                $this->migrateColumn($versionedTable, 'Title', 'LinkText');
+            }
+        }
+        $this->extend('afterMigrateTitleColumn');
+    }
+
+    /**
+     * Set the $migrateFromColumn value to the value of the $migrateToColumn column, but don't replace values that already exist.
+     */
+    private function migrateColumn(string $table, string $migrateFromColumn, string $migrateToColumn, bool $columnIsNumeric = false): void
+    {
+        // Give developers a chance to skip migrating this column
+        $shouldMigrateColumn = true;
+        $this->extend('updateShouldMigrateColumn', $table, $migrateFromColumn, $shouldMigrateColumn);
+        if (!$shouldMigrateColumn) {
+            $this->print("Skipping migration of '{$table}.{$migrateFromColumn}' column due to project-level customisation.");
+            return;
+        }
+        $db = DB::get_conn();
+        $fromDbColumn = $db->escapeIdentifier($table . '.' . $migrateFromColumn);
+        $toDbColumn = $db->escapeIdentifier($table . '.' . $migrateToColumn);
+        // Migrate the data
+        $nullCheck = $db->nullCheckClause($toDbColumn, true);
+        SQLUpdate::create(
+            $db->escapeIdentifier($table),
+            [$toDbColumn => [$fromDbColumn => []]],
+            // Only set if there's no value in that column already
+            [$columnIsNumeric ? "$toDbColumn = 0 OR $nullCheck" : $nullCheck]
+        )->execute();
+
+        // Give developers a chance to skip dropping from column
+        $shouldDropColumn = true;
+        $this->extend('updateShouldDropColumn', $table, $migrateFromColumn, $shouldDropColumn);
+        if (!$shouldDropColumn) {
+            $this->print("Skipping dropping '{$table}.{$migrateFromColumn}' column due to project-level customisation.");
+            return;
+        }
+        // Remove the column from the db
+        $this->print("Dropping '{$table}.{$migrateFromColumn}' column.");
+        $db->query("ALTER TABLE \"$table\" DROP COLUMN \"{$migrateFromColumn}\"");
+    }
+
+    private function migrateHasManyRelations(): void
+    {
+        $this->extend('beforeMigrateHasManyRelations');
+        $linksList = static::config()->get('has_many_links_data');
+
+        // Exit early if there's nothing to migrate
+        if (empty($linksList)) {
+            $this->print('No has_many relations to migrate.');
+            $this->extend('afterMigrateHasManyRelations');
+            return;
+        }
+
+        $this->print('Migrating has_many relations.');
+        $schema = DataObject::getSchema();
+        $db = DB::get_conn();
+        foreach ($linksList as $ownerClass => $relationData) {
+            foreach ($relationData as $hasManyRelation => $spec) {
+                $linkClass = $spec['linkClass'];
+                $hasOneRelation = $spec['hasOne'];
+                // Skip if the has_one relation still exists
+                if (array_key_exists($hasOneRelation, $this->getLinkRelationData($linkClass, 'has_one'))) {
+                    throw new RuntimeException("has_one relation '{$linkClass}.{$hasOneRelation} still exists. Cannot migrate has_many relation '{$ownerClass}.{$hasManyRelation}'.");
+                };
+                // Check if HasOneID column is in the base Link table
+                if (!array_key_exists("{$hasOneRelation}ID", DB::field_list(DataObject::getSchema()->baseDataTable(Link::class)))) {
+                    // This is an unusual situation, and is difficult to do generically since SQLUpdate in framework
+                    // can't use joins. We'll leave this scenario up to the developer to handle.
+                    $this->extend('migrateHasOneForLinkSubclass', $linkClass, $ownerClass, $hasOneRelation, $hasManyRelation);
+                    continue;
+                }
+                $linkTable = $schema->tableForField($linkClass, 'OwnerID');
+                $tables = [$linkTable];
+                // Include versioned tables if link is versioned
+                if (Link::has_extension(Versioned::class)) {
+                    $tables[] = "{$linkTable}_Versions";
+                    $tables[] = "{$linkTable}_Live";
+                }
+                // Migrate old has_one on link to the Owner relation.
+                foreach ($tables as $table) {
+                    // Only try migration if we have both columns (e.g. versioned tables may not have the old has_one column)
+                    $needColumns = ["{$hasOneRelation}ID", 'OwnerID'];
+                    $columnsInTable = array_keys(DB::field_list($table));
+                    if (array_intersect($needColumns, $columnsInTable) !== $needColumns) {
+                        continue;
+                    }
+                    $this->migrateColumn($table, "{$hasOneRelation}ID", 'OwnerID', true);
+                    // Only set Class and Relation where the ID got migrated
+                    $ownerIdColumn = $db->escapeIdentifier($table . '.OwnerID');
+                    $nullCheck = $db->nullCheckClause($ownerIdColumn, false);
+                    $whereClause = [
+                        "$ownerIdColumn != 0 AND $nullCheck",
+                        $db->nullCheckClause($db->escapeIdentifier($table . '.OwnerRelation'), true),
+                    ];
+                    $wasPolyMorphic = array_key_exists("{$hasOneRelation}Class", DB::field_list($table));
+                    if ($wasPolyMorphic) {
+                        // For polymorphic relations, don't set the class/relation columns for records belonging
+                        // to a different class hierarchy.
+                        $validClasses = ClassInfo::subclassesFor($ownerClass, true);
+                        $placeholders = DB::placeholders($validClasses);
+                        $whereClause[] = [$db->escapeIdentifier("{$table}.{$hasOneRelation}Class") . " IN ($placeholders)" => $validClasses];
+                    }
+                    // Make sure we get the actual class name, not just the base class name.
+                    $subSelect = SQLSelect::create(
+                        $schema->sqlColumnForField($ownerClass, 'ClassName'),
+                        $schema->baseDataTable($ownerClass),
+                        'ID = ' . $ownerIdColumn
+                    )->sql();
+                    SQLUpdate::create(
+                        $db->escapeIdentifier($table),
+                        [
+                            $db->escapeIdentifier($table . '.OwnerClass') => ["({$subSelect})" => []],
+                            $db->escapeIdentifier($table . '.OwnerRelation') => $hasManyRelation,
+                        ],
+                        $whereClause
+                    )->execute();
+                    if ($wasPolyMorphic) {
+                        $this->print("Dropping '{$table}.{$hasOneRelation}Class' column.");
+                        $db->query("ALTER TABLE \"$table\" DROP COLUMN \"{$hasOneRelation}Class\"");
+                    }
+                }
+            }
+        }
+        $this->extend('afterMigrateHasManyRelations');
+    }
+
+    /**
+     * Find all `has_one` relations to link and set the corresponding `Owner` relation
+     */
+    private function setOwnerForHasOneLinks(): void
+    {
+        $this->extend('beforeSetOwnerForHasOneLinks');
+        $this->print('Setting owners for has_one relations.');
+        $allDataObjectModels = ClassInfo::subclassesFor(DataObject::class, false);
+        $allLinkModels = ClassInfo::subclassesFor(Link::class, true);
+        foreach ($allDataObjectModels as $modelClass) {
+            if ($this->shouldSkipClassForOwnerCheck($modelClass)) {
+                continue;
+            }
+            $hasOnes = Config::forClass($modelClass)->uninherited('has_one') ?? [];
+            foreach ($hasOnes as $hasOneName => $spec) {
+                // Get the class of the has_one
+                $hasOneClass = $spec['class'] ?? null;
+                if (!is_array($spec)) {
+                    $hasOneClass = $spec;
+                    $spec = ['class' => $hasOneClass];
+                }
+
+                // Skip malformed has_one relations
+                if ($hasOneClass === null) {
+                    continue;
+                }
+
+                // Polymorphic has_one needs some extra handling
+                if ($hasOneClass === DataObject::class) {
+                    if ($this->hasReciprocalRelation($allLinkModels, $hasOneName, $modelClass)) {
+                        continue;
+                    }
+                    $this->updateOwnerForRelation(Link::class, $hasOneName, $modelClass, $spec);
+                    continue;
+                }
+
+                // Skip if the has_one isn't for Link, or points at a belongs_to or has_many on Link
+                if (!is_a($hasOneClass, Link::class, true)) {
+                    continue;
+                }
+                if ($this->hasReciprocalRelation([$hasOneClass], $hasOneName, $modelClass)) {
+                    continue;
+                }
+
+                // Update Owner for the relevant links to point at this relation
+                $this->updateOwnerForRelation($hasOneClass, $hasOneName, $modelClass);
+            }
+        }
+        $this->extend('afterSetOwnerForHasOneLinks');
+    }
+
+    private function shouldSkipClassForOwnerCheck(string $modelClass): bool
+    {
+        // This is a workaround for tests, since ClassInfo will get info about all TestOnly classes,
+        // even if they're not in your test class's "extra_dataobjects" list.
+        // Some classes don't have tables and don't NEED tables - but those classes also
+        // won't declare has_one relations, so it's okay to skip those too.
+        if (!ClassInfo::hasTable(DataObject::getSchema()->tableName($modelClass))) {
+            return true;
+        }
+        // Skip class hierarchies that we explicitly said we want to skip
+        $classHierarchiesToSkip = static::config()->get('classes_that_are_not_link_owners') ?? [];
+        foreach ($classHierarchiesToSkip as $skipClass) {
+            if (is_a($modelClass, $skipClass, true)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Store relation data in memory so we're not hitting config over and over again unnecessarily.
+     * The task is likely run in CLI which relies on filesystem cache for config.
+     */
+    private function getLinkRelationData(string $linkClass, string $configName): array
+    {
+        if (!isset($this->linkRelationData[$linkClass][$configName])) {
+            $config = Config::forClass($linkClass);
+            $this->linkRelationData[$linkClass][$configName] = $config->uninherited($configName) ?? [];
+        }
+        return $this->linkRelationData[$linkClass][$configName];
+    }
+
+    private function hasReciprocalRelation(array $linkClasses, string $hasOneName, string $foreignClass): bool
+    {
+        foreach ($linkClasses as $linkClass) {
+            $relationData = array_merge(
+                $this->getLinkRelationData($linkClass, 'belongs_to'),
+                $this->getLinkRelationData($linkClass, 'has_many'),
+            );
+            // Check if the given link class has a belongs_to or has_many pointing at the has_one relation
+            // we're asking about
+            foreach ($relationData as $relationName => $value) {
+                $parsedRelation = $this->parseRelationData($value);
+
+                if ($foreignClass !== $parsedRelation['class']) {
+                    continue;
+                }
+
+                // If we can't tell what relation the belongs_to or has_many points at,
+                // assume it's for the relation we're asking about
+                if ($parsedRelation['reciprocalRelation'] === null) {
+                    // Printing so developers can double check after the task is run.
+                    // They can manually set the owner if it turns out our assumption was wrong.
+                    // Not adding an extension point here because developers should use dot notation for the relation instead
+                    // of working around their ambiguous relation declaration.
+                    $this->print("Ambiguous relation '{$linkClass}.{$relationName}' found - assuming it points at '{$foreignClass}.{$hasOneName}'");
+                    return true;
+                }
+
+                if ($hasOneName !== $parsedRelation['reciprocalRelation']) {
+                    continue;
+                }
+
+                // If we get here, then the relation points back at the has_one we're
+                // checking against.
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Parses a belongs_to or has_many relation class to separate the class from
+     * the reciprocal relation name.
+     *
+     * Modified from RelationValidationService in framework.
+     */
+    private function parseRelationData(string $relationData): array
+    {
+        if (mb_strpos($relationData ?? '', '.') === false) {
+            return [
+                'class' => $relationData,
+                'reciprocalRelation' => null,
+            ];
+        }
+
+        $segments = explode('.', $relationData ?? '');
+
+        // Theoretically this is the same as the mb_strpos check above,
+        // but both checks are in RelationValidationService so I'm leaving
+        // this here in case there's some edge case it's covering.
+        if (count($segments) !== 2) {
+            return [
+                'class' => $relationData,
+                'reciprocalRelation' => null,
+            ];
+        }
+
+        $class = array_shift($segments);
+        $relation = array_shift($segments);
+        return [
+            'class' => $class,
+            'reciprocalRelation' => $relation,
+        ];
+    }
+
+    /**
+     * Bulk update the owner for links stored in a has_one relation
+     */
+    private function updateOwnerForRelation(string $linkClass, string $hasOneName, string $foreignClass, array $polymorphicSpec = []): void
+    {
+        $db = DB::get_conn();
+        $schema = DataObject::getSchema();
+        $isPolymorphic = !empty($polymorphicSpec);
+
+        $ownerIdColumn = $schema->sqlColumnForField($linkClass, 'OwnerID');
+        $ownerClassColumn = $schema->sqlColumnForField($linkClass, 'OwnerClass');
+        $ownerRelationColumn = $schema->sqlColumnForField($linkClass, 'OwnerRelation');
+        $linkIdColumn = $schema->sqlColumnForField($linkClass, 'ID');
+        $relationIdColumn = $schema->sqlColumnForField($foreignClass, "{$hasOneName}ID");
+
+        $nullCheck = $db->nullCheckClause($ownerIdColumn, true);
+        $baseTable = $schema->tableForField($linkClass, 'OwnerID');
+        $update = SQLUpdate::create(
+            $db->escapeIdentifier($baseTable),
+            [
+                $ownerIdColumn => [$schema->sqlColumnForField($foreignClass, 'ID') => []],
+                $ownerClassColumn => [$schema->sqlColumnForField($foreignClass, 'ClassName') => []],
+                $ownerRelationColumn => $hasOneName,
+            ],
+            [
+                $linkIdColumn . ' = ' . $relationIdColumn,
+                // Only set the owner if it isn't already set
+                // Don't check class here - see https://github.com/silverstripe/silverstripe-framework/issues/11165
+                "$ownerIdColumn = 0 OR $nullCheck",
+                $db->nullCheckClause($ownerRelationColumn, true),
+            ]
+        );
+        // Join the table for $foreignClass
+        $foreignClassTable = $schema->tableName($foreignClass);
+        if ($foreignClassTable !== $baseTable) {
+            $update->addInnerJoin($foreignClassTable, $relationIdColumn . ' = ' . $linkIdColumn);
+            // If the table for $foreignClass is not its base table, we need to join that as well
+            // so we can get the ID and classname.
+            $baseForeignTable = $schema->baseDataTable($foreignClass);
+            if (!$update->isJoinedTo($baseForeignTable)) {
+                $update->addInnerJoin(
+                    $baseForeignTable,
+                    $db->escapeIdentifier($baseForeignTable . '.ID') . ' = ' . $db->escapeIdentifier($foreignClassTable . '.ID')
+                );
+            }
+            // Add join and where clauses for polymorphic relations so we don't set the wrong owners
+            if ($isPolymorphic) {
+                $relationClassColumn = $schema->sqlColumnForField($foreignClass, "{$hasOneName}Class");
+                $linkClassColumn = $schema->sqlColumnForField($linkClass, 'ClassName');
+                $update->addFilterToJoin($foreignClassTable, $relationClassColumn . ' = ' . $linkClassColumn);
+                // Make sure we ignore any multi-relational has_one pointing at something other than Link.Owner
+                if ($polymorphicSpec[DataObjectSchema::HAS_ONE_MULTI_RELATIONAL] ?? false) {
+                    $update->addWhere([$schema->sqlColumnForField($foreignClass, "{$hasOneName}Relation") => 'Owner']);
+                }
+            }
+        }
+        $update->execute();
+    }
+
+    /**
+     * Publishes links unless Link isn't versioned or developers opt out.
+     */
+    private function publishLinks(): void
+    {
+        if (Link::has_extension(Versioned::class)) {
+            $shouldPublishLinks = true;
+            $this->extend('updateShouldPublishLinks', $shouldPublishLinks);
+            if ($shouldPublishLinks) {
+                $this->print('Publishing links.');
+                /** @var Versioned&Link $link */
+                foreach (Link::get()->chunkedFetch() as $link) {
+                    // Allow developers to skip publishing each link - this allows for scenarios
+                    // where links were Versioned in v2/v3 projects.
+                    $shouldPublishLink = true;
+                    $this->extend('updateShouldPublishLink', $link, $shouldPublishLink);
+                    if ($shouldPublishLink) {
+                        $link->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
+                    }
+                    $link->destroy();
+                }
+                $this->print('Publishing complete.');
+            } else {
+                $this->print('Skipping publish step.');
+            }
+        } else {
+            $this->print('Links are not versioned - skipping publish step due to project-level customisation.');
+        }
+    }
+
+    /**
+     * Check for broken links and output information about them.
+     * Doesn't actually check if file or page exists for those link types,
+     * this is just about whether there's data there or not.
+     */
+    private function checkForBrokenLinks(): void
+    {
+        $this->print('Checking for broken links.');
+        // Using draft stage is safe for unversioned links, and ensures we
+        // get all relevant data for versioned but unpublished links.
+        Versioned::withVersionedMode(function () {
+            Versioned::set_reading_mode('Stage.' . Versioned::DRAFT);
+            $checkForBrokenLinks = [
+                EmailLink::class => [
+                    'field' => 'Email',
+                    'emptyValue' => [null, ''],
+                ],
+                ExternalLink::class => [
+                    'field' => 'ExternalUrl',
+                    'emptyValue' => [null, ''],
+                ],
+                FileLink::class => [
+                    'field' => 'FileID',
+                    'emptyValue' => [null, 0],
+                ],
+                PhoneLink::class => [
+                    'field' => 'Phone',
+                    'emptyValue' => [null, ''],
+                ],
+                SiteTreeLink::class => [
+                    'field' => 'PageID',
+                    'emptyValue' => [null, 0],
+                ],
+            ];
+            $this->extend('updateCheckForBrokenLinks', $checkForBrokenLinks);
+            $brokenLinks = [];
+            foreach ($checkForBrokenLinks as $class => $data) {
+                $field = $data['field'];
+                $emptyValue = $data['emptyValue'];
+                $ids = DataObject::get($class)->filter([$field => $emptyValue])->column('ID');
+                $numBroken = count($ids);
+                $this->print("Found $numBroken broken links for the '$class' class.");
+                if ($numBroken > 0) {
+                    $brokenLinks[$class] = $ids;
+                }
+            }
+
+            if (empty($brokenLinks)) {
+                $this->print('No broken links.');
+                return;
+            }
+
+            // Output table of broken links
+            $this->print('Broken links:');
+            if (Director::is_cli()) {
+                // Output in a somewhat CLI friendly table.
+                // Pad by the length of the longest class name so things align nicely.
+                $longestClassLen = max(array_map('strlen', array_keys($brokenLinks)));
+                $paddedClassTitle = str_pad('Link class', $longestClassLen);
+                $classSeparator = str_repeat('-', $longestClassLen);
+                $output = <<< CLI_TABLE
+                $paddedClassTitle | IDs of broken links
+                $classSeparator | -------------------
+                CLI_TABLE;
+                foreach ($brokenLinks as $class => $ids) {
+                    $paddedClass = str_pad($class, $longestClassLen);
+                    $idsString = implode(', ', $ids);
+                    $output .= "\n$paddedClass | $idsString";
+                }
+            } else {
+                // Output as an HTML table
+                $output = '<table><thead><tr><th>Link class</th><th>IDs of broken links</th></tr></thead><tbody>';
+                foreach ($brokenLinks as $class => $ids) {
+                    $idsString = implode(', ', $ids);
+                    $output .= "<tr><td>$class</td><td>$idsString</td></tr>";
+                }
+                $output .= '</tbody></table>';
+            }
+            $this->print($output);
+        });
+    }
+
+    /**
+     * A convenience method for printing a line to the browser or terminal with appropriate line breaks.
+     */
+    private function print(string $message): void
+    {
+        $eol = Director::is_cli() ? "\n" : '<br>';
+        echo $message . $eol;
+    }
+}

--- a/tests/php/Models/LinkTest/LinkOwner.php
+++ b/tests/php/Models/LinkTest/LinkOwner.php
@@ -9,6 +9,8 @@ use SilverStripe\Versioned\Versioned;
 
 class LinkOwner extends DataObject implements TestOnly
 {
+    private static string $table_name = 'LinkFieldTest_Models_LinkOwner';
+
     private static array $has_one = [
         'Link' => Link::class,
     ];

--- a/tests/php/Tasks/LinkFieldMigrationTaskTest.php
+++ b/tests/php/Tasks/LinkFieldMigrationTaskTest.php
@@ -1,0 +1,1144 @@
+<?php declare(strict_types=1);
+
+namespace SilverStripe\LinkField\Tests\Tasks;
+
+use LogicException;
+use ReflectionMethod;
+use ReflectionProperty;
+use RuntimeException;
+use SilverStripe\Core\Convert;
+use SilverStripe\Core\Environment;
+use SilverStripe\Core\Manifest\ClassLoader;
+use SilverStripe\Dev\Deprecation;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\LinkField\Models\EmailLink;
+use SilverStripe\LinkField\Models\ExternalLink;
+use SilverStripe\LinkField\Models\FileLink;
+use SilverStripe\LinkField\Models\Link;
+use SilverStripe\LinkField\Models\PhoneLink;
+use SilverStripe\LinkField\Models\SiteTreeLink;
+use SilverStripe\LinkField\Tasks\LinkFieldMigrationTask;
+use SilverStripe\LinkField\Tests\Models\LinkTest\LinkOwner;
+use SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\AmbiguousLinkOwner;
+use SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\CustomLink;
+use SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\CustomLinkMigrationExtension;
+use SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\HasManyLinkOwner;
+use SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\MultiLinkOwner;
+use SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\OverrideMigrationStepsExtension;
+use SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\PolymorphicLinkOwner;
+use SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\ReciprocalLinkOwner;
+use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\ORM\FieldType\DBInt;
+use SilverStripe\ORM\FieldType\DBVarchar;
+use SilverStripe\ORM\Queries\SQLSelect;
+use SilverStripe\ORM\Queries\SQLUpdate;
+use SilverStripe\Versioned\Versioned;
+use Symfony\Component\DomCrawler\Crawler;
+
+class LinkFieldMigrationTaskTest extends SapphireTest
+{
+    protected static $fixture_file = 'LinkFieldMigrationTaskTest.yml';
+
+    protected static $extra_dataobjects = [
+        CustomLink::class,
+        AmbiguousLinkOwner::class,
+        HasManyLinkOwner::class,
+        LinkOwner::class,
+        MultiLinkOwner::class,
+        ReciprocalLinkOwner::class,
+        PolymorphicLinkOwner::class,
+    ];
+
+    protected static $required_extensions = [
+        LinkFieldMigrationTask::class => [
+            OverrideMigrationStepsExtension::class,
+            CustomLinkMigrationExtension::class,
+        ]
+    ];
+
+    /**
+     * Required because of all the creations and deletions of columns.
+     * Without this, tests pass individually but fail when run as a class.
+     */
+    protected $usesTransactions = false;
+
+    private bool $needsResetSchema = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Remove AmbiguousLinkOwner class from class manifest for all tests that it interferes with.
+        $name = $this->getName(false);
+        if (str_starts_with($name, 'testSetOwnerForHasOneLinks') && $name !== 'testSetOwnerForHasOneLinksAmbiguous') {
+            $this->needsResetSchema = true;
+            $classManifest = ClassLoader::inst()->getManifest();
+            $reflectionGetState = new ReflectionMethod($classManifest, 'getState');
+            $reflectionGetState->setAccessible(true);
+            $state = $reflectionGetState->invoke($classManifest);
+            $lowerCaseClass = strtolower(AmbiguousLinkOwner::class);
+            foreach (array_keys($state) as $property) {
+                switch ($property) {
+                    case 'descendants':
+                        unset($state[$property][$lowerCaseClass]);
+                        unset($state[$property][strtolower(DataObject::class)][$lowerCaseClass]);
+                        break;
+                    case 'classes':
+                    case 'classNames':
+                        unset($state[$property][$lowerCaseClass]);
+                        break;
+                }
+            }
+            $reflectionLoadState = new ReflectionMethod($classManifest, 'loadState');
+            $reflectionLoadState->setAccessible(true);
+            $reflectionLoadState->invokeArgs($classManifest, [$state]);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        // Reset static properties
+        OverrideMigrationStepsExtension::$shouldPublishLink = null;
+        OverrideMigrationStepsExtension::$shouldPublishLinks = null;
+        OverrideMigrationStepsExtension::$needsMigration = null;
+        OverrideMigrationStepsExtension::$shouldMigrateColumn = [];
+        OverrideMigrationStepsExtension::$shouldDropColumn = [];
+        // Add versioning back - should probably be done by whatever flushes cache, but apparently not.
+        if (!Link::has_extension(Versioned::class)) {
+            Link::add_extension(Versioned::class);
+        }
+        // Make sure AmbiguousLinkOwner class exists
+        if ($this->needsResetSchema) {
+            ClassLoader::inst()->getManifest()->regenerate(true);
+            DataObject::getSchema()->reset();
+        }
+        parent::tearDown();
+    }
+
+    public function provideGetNeedsMigration(): array
+    {
+        $scenarios = [
+            'has both columns' => [
+                'hasTitleColumn' => true,
+                'hasLinkTextColumn' => true,
+                'extensionOverride' => null,
+                'expected' => true,
+            ],
+            'missing Title column' => [
+                'hasTitleColumn' => false,
+                'hasLinkTextColumn' => true,
+                'extensionOverride' => null,
+                'expected' => false,
+            ],
+            'missing LinkText column' => [
+                'hasTitleColumn' => true,
+                'hasLinkTextColumn' => false,
+                'extensionOverride' => null,
+                'expected' => false,
+            ],
+            'missing both columns' => [
+                'hasTitleColumn' => false,
+                'hasLinkTextColumn' => false,
+                'extensionOverride' => null,
+                'expected' => false,
+            ],
+        ];
+        foreach ($scenarios as $title => $scenario) {
+            $scenario['extensionOverride'] = true;
+            $scenario['expected'] = true;
+            $scenarios[$title . ' (override to true)'] = $scenario;
+            $scenario['extensionOverride'] = false;
+            $scenario['expected'] = false;
+            $scenarios[$title . ' (override to false)'] = $scenario;
+        }
+        return $scenarios;
+    }
+
+    /**
+     * @dataProvider provideGetNeedsMigration
+     */
+    public function testGetNeedsMigration(bool $hasTitleColumn, bool $hasLinkTextColumn, ?bool $extensionOverride, bool $expected): void
+    {
+        // Add/remove columns as necessary to replicate migration scenario
+        $baseTable = DataObject::getSchema()->baseDataTable(Link::class);
+        if (!$hasLinkTextColumn) {
+            DB::get_conn()->query("ALTER TABLE \"$baseTable\" DROP COLUMN \"LinkText\"");
+        }
+        if ($hasTitleColumn) {
+            $this->ensureColumnsExist(['Title' => DBVarchar::class], false);
+        }
+        // Set extension to override as appropriate
+        OverrideMigrationStepsExtension::$needsMigration = $extensionOverride;
+
+        $this->startCapturingOutput();
+        $needsMigration = $this->callPrivateMethod('getNeedsMigration', [$baseTable]);
+        $output = $this->stopCapturingOutput();
+
+        $this->assertSame($expected, $needsMigration);
+
+        // Extension overrides can affect the output
+        $expectedOutput = '';
+        if ($extensionOverride && (!$hasLinkTextColumn || !$hasTitleColumn)) {
+            $expectedOutput = "Not skipping migration due to project-level customisation.\n";
+        } elseif ($extensionOverride === false && $hasLinkTextColumn && $hasTitleColumn) {
+            $expectedOutput = "Skipping migration due to project-level customisation.\n";
+        }
+
+        // Output should indicate why migration can't be performed
+        if (!$hasLinkTextColumn && !$hasTitleColumn) {
+            $expectedOutput .= "Missing multiple columns in the database. This usually happens in new installations before dev/build.\n";
+        } elseif (!$hasLinkTextColumn) {
+            $expectedOutput .= 'Missing "LinkText" column in database. This usually means you need to upgrade your silverstripe/linkfield dependency and run dev/build.' . "\n";
+        } elseif (!$hasTitleColumn) {
+            $expectedOutput .= 'Missing "Title" column in database. This usually means you have already run this task or do not need to migrate.' . "\n";
+        }
+
+        $this->assertSame($expectedOutput, $output);
+    }
+
+    public function provideMigrateTitleColumnUnversioned(): array
+    {
+        return [
+            'full migration' => [
+                'skipMigration' => false,
+                'skipDropColumn' => false,
+                'v3IsVersioned' => false,
+            ],
+            'skip migration' => [
+                'skipMigration' => true,
+                'skipDropColumn' => false,
+                'v3IsVersioned' => false,
+            ],
+            'skip drop column' => [
+                'skipMigration' => false,
+                'skipDropColumn' => true,
+                'v3IsVersioned' => false,
+            ],
+            'full migration, v3 is versioned' => [
+                'skipMigration' => false,
+                'skipDropColumn' => false,
+                'v3IsVersioned' => true,
+            ]
+        ];
+    }
+
+    /**
+     * Tests migrating data when v2 and v3 were NOT versioned
+     * @dataProvider provideMigrateTitleColumnUnversioned
+     */
+    public function testMigrateTitleColumnUnversioned(bool $skipMigration, bool $skipDropColumn, bool $v3IsVersioned): void
+    {
+        // Make sure the Title column exists before we start
+        $this->ensureColumnsExist(['Title' => DBVarchar::class], false);
+
+        $schema = DataObject::getSchema();
+        $baseTable = $schema->baseDataTable(Link::class);
+        if ($skipMigration) {
+            OverrideMigrationStepsExtension::$shouldMigrateColumn[$baseTable] = false;
+        }
+        if ($skipDropColumn) {
+            OverrideMigrationStepsExtension::$shouldDropColumn[$baseTable] = false;
+        }
+        // Add content to the "Title" column for various links
+        $ids = [
+            'test-email-link01' => $this->idFromFixture(EmailLink::class, 'test-email-link01'),
+            'test-email-link02' => $this->idFromFixture(EmailLink::class, 'test-email-link02'),
+            'test-email-link03' => $this->idFromFixture(EmailLink::class, 'test-email-link03'),
+            'test-external-link01' => $this->idFromFixture(ExternalLink::class, 'test-external-link01'),
+            'test-external-link02' => $this->idFromFixture(ExternalLink::class, 'test-external-link02'),
+            'test-external-link03' => $this->idFromFixture(ExternalLink::class, 'test-external-link03'),
+            'test-file-link01' => $this->idFromFixture(FileLink::class, 'test-file-link01'),
+            'test-file-link02' => $this->idFromFixture(FileLink::class, 'test-file-link02'),
+            'test-file-link03' => $this->idFromFixture(FileLink::class, 'test-file-link03'),
+            'test-phone-link01' => $this->idFromFixture(PhoneLink::class, 'test-phone-link01'),
+            'test-phone-link02' => $this->idFromFixture(PhoneLink::class, 'test-phone-link02'),
+            'test-phone-link03' => $this->idFromFixture(PhoneLink::class, 'test-phone-link03'),
+            'test-sitetree-link01' => $this->idFromFixture(SiteTreeLink::class, 'test-sitetree-link01'),
+            'test-sitetree-link02' => $this->idFromFixture(SiteTreeLink::class, 'test-sitetree-link02'),
+            'test-sitetree-link03' => $this->idFromFixture(SiteTreeLink::class, 'test-sitetree-link03'),
+            'test-custom-link01' => $this->idFromFixture(CustomLink::class, 'test-custom-link01'),
+            'test-custom-link02' => $this->idFromFixture(CustomLink::class, 'test-custom-link02'),
+            'test-custom-link03' => $this->idFromFixture(CustomLink::class, 'test-custom-link03'),
+        ];
+        // e.g. for a link with ID=1, the title will be "link title #1"
+        $db = DB::get_conn();
+        $titleColumn = $db->escapeIdentifier($baseTable . '.Title');
+        $idColumn = $schema->sqlColumnForField(Link::class, 'ID');
+        $placeholders = DB::placeholders($ids);
+        $update = new SQLUpdate(
+            $db->escapeIdentifier($baseTable),
+            [$titleColumn => ["CONCAT('link title #', $idColumn)" => []]],
+            ["$idColumn in ($placeholders)" => array_values($ids)]
+        );
+        $update->execute();
+
+        if ($this->usesTransactions) {
+            // This is required to allow SQLUpdate changes to be rolled back on tearDown
+            static::tempDB()->startTransaction();
+        }
+        if (!$v3IsVersioned) {
+            Link::remove_extension(Versioned::class);
+        }
+        $this->startCapturingOutput();
+        $this->callPrivateMethod('migrateTitleColumn');
+        $output = $this->stopCapturingOutput();
+
+        // Test output, which will be different if we're skipping things
+        $expectedOutput = "Migrating data in '$baseTable' table.\n";
+        if ($skipMigration) {
+            $expectedOutput .= "Skipping migration of '{$baseTable}.Title' column due to project-level customisation.\n";
+        } else {
+            if ($skipDropColumn) {
+                $expectedOutput .= "Skipping dropping '{$baseTable}.Title' column due to project-level customisation.\n";
+            } else {
+                $expectedOutput .= "Dropping '{$baseTable}.Title' column.\n";
+            }
+        }
+        if ($v3IsVersioned) {
+            $expectedOutput .= "Nothing to migrate in '{$baseTable}_Versions' table.\n";
+            $expectedOutput .= "Nothing to migrate in '{$baseTable}_Live' table.\n";
+        }
+        $this->assertSame($expectedOutput, $output);
+
+        // Test LinkText values
+        foreach ($ids as $fixtureName => $id) {
+            if (str_ends_with($fixtureName, '01')) {
+                // These fixtures already had LinkText, which should not have changed.
+                $expectedLinkText = $fixtureName;
+            } elseif ($skipMigration) {
+                $expectedLinkText = null;
+            } else {
+                $expectedLinkText = 'link title #' . $id;
+            }
+            $this->assertSame($expectedLinkText, Link::get()->byID($id)->LinkText);
+        }
+
+        // Test whether Title column was dropped
+        if ($skipMigration || $skipDropColumn) {
+            $this->assertTrue(
+                in_array('Title', array_keys(DB::field_list($baseTable))),
+                'Title column should NOT be removed'
+            );
+        } else {
+            $this->assertFalse(
+                in_array('Title', array_keys(DB::field_list($baseTable))),
+                'Title column should be removed'
+            );
+        }
+    }
+
+    public function provideMigrateTitleColumnVersioned(): array
+    {
+        return [
+            'full migration' => [
+                'skipMigration' => null,
+                'skipDropColumn' => null,
+            ],
+            'skip migration for Versions table' => [
+                'skipMigration' => '_Versions',
+                'skipDropColumn' => null,
+            ],
+            'skip drop column for Versions table' => [
+                'skipMigration' => null,
+                'skipDropColumn' => '_Versions',
+            ],
+        ];
+    }
+
+    /**
+     * Tests migrating data when v2 and v3 WERE versioned
+     * @dataProvider provideMigrateTitleColumnVersioned
+     */
+    public function testMigrateTitleColumnVersioned(?string $skipMigration, ?string $skipDropColumn): void
+    {
+        // Publish all links before we start so there's data in the _Versions and _Live columns
+        Link::get()->each(fn(Link $link) => $link->publishSingle());
+
+        // Make sure the Title column exists before we start
+        $this->ensureColumnsExist(['Title' => DBVarchar::class]);
+
+        $schema = DataObject::getSchema();
+        $baseTable = $schema->baseDataTable(Link::class);
+        if ($skipMigration) {
+            OverrideMigrationStepsExtension::$shouldMigrateColumn[$baseTable . $skipMigration] = false;
+        }
+        if ($skipDropColumn) {
+            OverrideMigrationStepsExtension::$shouldDropColumn[$baseTable . $skipDropColumn] = false;
+        }
+        // Add content to the "Title" column for various links
+        $ids = [
+            'test-email-link01' => $this->idFromFixture(EmailLink::class, 'test-email-link01'),
+            'test-email-link02' => $this->idFromFixture(EmailLink::class, 'test-email-link02'),
+            'test-email-link03' => $this->idFromFixture(EmailLink::class, 'test-email-link03'),
+            'test-external-link01' => $this->idFromFixture(ExternalLink::class, 'test-external-link01'),
+            'test-external-link02' => $this->idFromFixture(ExternalLink::class, 'test-external-link02'),
+            'test-external-link03' => $this->idFromFixture(ExternalLink::class, 'test-external-link03'),
+            'test-file-link01' => $this->idFromFixture(FileLink::class, 'test-file-link01'),
+            'test-file-link02' => $this->idFromFixture(FileLink::class, 'test-file-link02'),
+            'test-file-link03' => $this->idFromFixture(FileLink::class, 'test-file-link03'),
+            'test-phone-link01' => $this->idFromFixture(PhoneLink::class, 'test-phone-link01'),
+            'test-phone-link02' => $this->idFromFixture(PhoneLink::class, 'test-phone-link02'),
+            'test-phone-link03' => $this->idFromFixture(PhoneLink::class, 'test-phone-link03'),
+            'test-sitetree-link01' => $this->idFromFixture(SiteTreeLink::class, 'test-sitetree-link01'),
+            'test-sitetree-link02' => $this->idFromFixture(SiteTreeLink::class, 'test-sitetree-link02'),
+            'test-sitetree-link03' => $this->idFromFixture(SiteTreeLink::class, 'test-sitetree-link03'),
+            'test-custom-link01' => $this->idFromFixture(CustomLink::class, 'test-custom-link01'),
+            'test-custom-link02' => $this->idFromFixture(CustomLink::class, 'test-custom-link02'),
+            'test-custom-link03' => $this->idFromFixture(CustomLink::class, 'test-custom-link03'),
+        ];
+        // e.g. for a link with ID=1, the title will be "link title #1"
+        $db = DB::get_conn();
+        $titleColumn = $db->escapeIdentifier($baseTable . '.Title');
+        $idColumn = $schema->sqlColumnForField(Link::class, 'ID');
+        $placeholders = DB::placeholders($ids);
+        foreach (['', '_Versions', '_Live'] as $suffix) {
+            $versionedTable = $baseTable . $suffix;
+            $versionedTitleColumn = str_replace($baseTable, $versionedTable, $titleColumn);
+            $versionedIdColumn = str_replace($baseTable, $versionedTable, $idColumn);
+            $update = new SQLUpdate(
+                $db->escapeIdentifier($versionedTable),
+                [$versionedTitleColumn => ["CONCAT('link title #', $versionedIdColumn)" => []]],
+                ["$versionedIdColumn in ($placeholders)" => array_values($ids)]
+            );
+            $update->execute();
+        }
+
+        if ($this->usesTransactions) {
+            // This is required to allow SQLUpdate changes to be rolled back on tearDown
+            static::tempDB()->startTransaction();
+        }
+        $this->startCapturingOutput();
+        $this->callPrivateMethod('migrateTitleColumn');
+        $output = $this->stopCapturingOutput();
+
+        // Test output, which will be different if we're skipping things
+        $expectedOutput = '';
+        foreach (['', '_Versions', '_Live'] as $suffix) {
+            $expectedOutput .= "Migrating data in '{$baseTable}{$suffix}' table.\n";
+            if ($skipMigration === $suffix) {
+                $expectedOutput .= "Skipping migration of '{$baseTable}{$suffix}.Title' column due to project-level customisation.\n";
+            } else {
+                if ($skipDropColumn === $suffix) {
+                    $expectedOutput .= "Skipping dropping '{$baseTable}{$suffix}.Title' column due to project-level customisation.\n";
+                } else {
+                    $expectedOutput .= "Dropping '{$baseTable}{$suffix}.Title' column.\n";
+                }
+            }
+        }
+        $this->assertSame($expectedOutput, $output);
+
+        // Test LinkText values
+        foreach ($ids as $fixtureName => $id) {
+            foreach (['', '_Versions', '_Live'] as $suffix) {
+                if (str_ends_with($fixtureName, '01')) {
+                    // These fixtures already had LinkText, which should not have changed.
+                    $expectedLinkText = $fixtureName;
+                } elseif ($skipMigration === $suffix) {
+                    $expectedLinkText = null;
+                } else {
+                    $expectedLinkText = 'link title #' . $id;
+                }
+                $versionedTable = $baseTable . $suffix;
+                $idColumn = $db->escapeIdentifier($versionedTable . '.ID');
+                $select = new SQLSelect('LinkText', [$versionedTable], [$idColumn => $id]);
+                $this->assertSame($expectedLinkText, $select->execute()->value());
+            }
+        }
+
+        // Test whether Title column was dropped
+        foreach (['', '_Versions', '_Live'] as $suffix) {
+            if ($skipMigration === $suffix || $skipDropColumn === $suffix) {
+                $this->assertTrue(
+                    in_array('Title', array_keys(DB::field_list($baseTable . $suffix))),
+                    'Title column should NOT be removed - suffix: ' . $suffix
+                );
+            } else {
+                $this->assertFalse(
+                    in_array('Title', array_keys(DB::field_list($baseTable . $suffix))),
+                    'Title column should be removed - suffix: ' . $suffix
+                );
+            }
+        }
+    }
+
+    public function provideSetOwnerForHasOneLinks(): array
+    {
+        return [
+            [
+                'ownerClass' => LinkOwner::class,
+                'fixtureRelationsHaveLink' => [
+                    'owns-has-one' => [
+                        // Link exists and Owner relation is set to this record
+                        'Link' => true,
+                    ],
+                    'owns-has-one-again' => [
+                        // Link exists but Owner relation is NOT set to this record
+                        'Link' => false,
+                    ],
+                    'owns-nothing' => [
+                        // Link does not exist
+                        'Link' => null,
+                    ],
+                ],
+            ],
+            [
+                'ownerClass' => MultiLinkOwner::class,
+                'fixtureRelationsHaveLink' => [
+                    'owns-one' => [
+                        'LinkOne' => true,
+                        'LinkTwo' => null,
+                        'NotLink' => null,
+                    ],
+                    'owns-another' => [
+                        'LinkOne' => null,
+                        'LinkTwo' => true,
+                        'NotLink' => null,
+                    ],
+                    'owns-multiple' => [
+                        'LinkOne' => true,
+                        'LinkTwo' => true,
+                        'NotLink' => null,
+                    ],
+                ],
+            ],
+            [
+                'ownerClass' => ReciprocalLinkOwner::class,
+                'fixtureRelationsHaveLink' => [
+                    'owns-many' => [
+                        'BaseLink' => true,
+                        'CustomLink' => true,
+                        'BelongsToLink' => false,
+                        'HasManyLink' => false,
+                    ],
+                ],
+            ],
+            [
+                'ownerClass' => PolymorphicLinkOwner::class,
+                'fixtureRelationsHaveLink' => [
+                    'owns-many' => [
+                        'PolymorphicLink' => true,
+                        'PolymorphicReciprocalLink' => false,
+                        'MultiRelationalLinkOne' => true,
+                        'MultiRelationalLinkTwo' => false,
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideSetOwnerForHasOneLinks
+     */
+    public function testSetOwnerForHasOneLinks(string $ownerClass, array $fixtureRelationsHaveLink): void
+    {
+        $this->startCapturingOutput();
+        $this->callPrivateMethod('setOwnerForHasOneLinks');
+        $output = $this->stopCapturingOutput();
+
+        $relationsByID = [];
+        foreach ($fixtureRelationsHaveLink as $fixture => $data) {
+            $data['fixture'] = $fixture;
+            $relationsByID[$this->idFromFixture($ownerClass, $fixture)] = $data;
+        }
+
+        foreach (DataObject::get($ownerClass) as $owner) {
+            if (array_key_exists($owner->ID, $relationsByID)) {
+                $data = $relationsByID[$owner->ID];
+                $ownerFixture = $data['fixture'];
+                $record = $this->objFromFixture($ownerClass, $ownerFixture);
+                foreach ($data as $relation => $hasLink) {
+                    if ($relation === 'fixture') {
+                        continue;
+                    }
+                    /** @var Link $link */
+                    $link = $record->$relation();
+                    if ($hasLink === null) {
+                        // Relation should either not be for link, or should not be in the DB.
+                        if (is_a($link->ClassName, Link::class, true)) {
+                            $this->assertFalse($link->isInDB(), "Relation {$relation} should not have a link saved in it");
+                        }
+                        continue;
+                    } elseif ($hasLink === false) {
+                        // The special case is where the Owner relation was already set to a different record.
+                        $isSpecialCase = $ownerClass === LinkOwner::class && $ownerFixture === 'owns-has-one-again';
+                        // Relation should be for link, but should not have its Owner set.
+                        $this->assertTrue($link->isInDB(), "Relation {$relation} should have a link saved in it");
+                        // Can't check OwnerClass here - see https://github.com/silverstripe/silverstripe-framework/issues/11165
+                        $this->assertSame(
+                            [
+                                $isSpecialCase ? $this->idFromFixture(LinkOwner::class, 'owns-has-one') : 0,
+                                $isSpecialCase ? 'Link' : null
+                            ],
+                            [
+                                $link->OwnerID,
+                                $link->OwnerRelation,
+                            ],
+                            "Relation {$relation} should not have an Owner set"
+                        );
+                        continue;
+                    }
+                    $this->assertTrue($link->isInDB(), "Relation {$relation} should have a link saved in it");
+                    $this->assertSame(
+                        [
+                            $owner->ID,
+                            $owner->ClassName,
+                            $relation,
+                        ],
+                        [
+                            $link->OwnerID,
+                            $link->OwnerClass,
+                            $link->OwnerRelation,
+                        ],
+                        "Relation {$relation} should have an Owner set"
+                    );
+                }
+            }
+        }
+
+        $this->assertSame("Setting owners for has_one relations.\n", $output);
+    }
+
+    public function provideSetOwnerForHasOneLinksSkipClass(): array
+    {
+        return [
+            'skip all DataObjects' => [
+                'skipHierarchy' => DataObject::class,
+            ],
+            'just skip LinkOwner' => [
+                'skipHierarchy' => LinkOwner::class,
+            ],
+        ];
+    }
+
+    /**
+     * Tests that classes_that_are_not_link_owners skips both the class itself and all its subclasses.
+     * @dataProvider provideSetOwnerForHasOneLinksSkipClass
+     */
+    public function testSetOwnerForHasOneLinksSkipClass(string $skipHierarchy): void
+    {
+        LinkFieldMigrationTask::config()->merge('classes_that_are_not_link_owners', [$skipHierarchy]);
+
+        $this->startCapturingOutput();
+        $this->callPrivateMethod('setOwnerForHasOneLinks');
+        $output = $this->stopCapturingOutput();
+
+        $idsToFixtures = [
+            $this->idFromFixture(LinkOwner::class, 'owns-has-one') => 'owns-has-one',
+            $this->idFromFixture(LinkOwner::class, 'owns-has-one-again') => 'owns-has-one-again',
+            $this->idFromFixture(LinkOwner::class, 'owns-nothing') => 'owns-nothing',
+        ];
+
+        foreach (LinkOwner::get() as $owner) {
+            if (!array_key_exists($owner->ID, $idsToFixtures)) {
+                continue;
+            }
+            $fixture = $idsToFixtures[$owner->ID];
+            $link = $owner->Link();
+            // Can't check OwnerClass here - see https://github.com/silverstripe/silverstripe-framework/issues/11165
+            $this->assertSame(
+                [
+                    $fixture === 'owns-nothing' ? null : 0,
+                    null
+                ],
+                [
+                    $link->OwnerID,
+                    $link->OwnerRelation,
+                ],
+                "Link for fixture {$fixture} should not have its Owner relation set."
+            );
+        }
+
+        $this->assertSame("Setting owners for has_one relations.\n", $output);
+    }
+
+    /**
+     * Tests output and result for setOwnerForHasOneLinks when the relation has an ambiguous reciprocal relation
+     */
+    public function testSetOwnerForHasOneLinksAmbiguous(): void
+    {
+        $this->startCapturingOutput();
+        $this->callPrivateMethod('setOwnerForHasOneLinks');
+        $output = $this->stopCapturingOutput();
+
+        $record = $this->objFromFixture(AmbiguousLinkOwner::class, 'owns-one');
+        /** @var Link $link */
+        $link = $record->Link();
+
+        // Check link exists, but doesn't have its Owner relation set.
+        $this->assertTrue($link->isInDB());
+        // Can't check OwnerClass here - see https://github.com/silverstripe/silverstripe-framework/issues/11165
+        $this->assertSame(
+            [
+                0,
+                null
+            ],
+            [
+                $link->OwnerID,
+                $link->OwnerRelation,
+            ]
+        );
+
+        $linkClass = CustomLink::class;
+        $foreignClass = AmbiguousLinkOwner::class;
+        $this->assertSame("Setting owners for has_one relations.\nAmbiguous relation '{$linkClass}.AmbiguousOwner' found - assuming it points at '{$foreignClass}.Link'\n", $output);
+    }
+
+    public function provideMigrateHasManyRelations(): array
+    {
+        return [
+            'no has_many' => [
+                'hasManyConfig' => [],
+            ],
+            'has_one for has_many still exists' => [
+                'hasManyConfig' => [
+                    HasManyLinkOwner::class => [
+                        'ForHasOne' => [
+                            'linkClass' => CustomLink::class,
+                            'hasOne' => 'ForHasMany',
+                        ],
+                    ],
+                ],
+                'ownerFixture' => 'still-has-relation',
+                'addColumns' => [],
+                'relationStillExists' => true,
+            ],
+            'regular has_one' => [
+                'hasManyConfig' => [
+                    HasManyLinkOwner::class => [
+                        'RegularHasMany' => [
+                            'linkClass' => Link::class,
+                            'hasOne' => 'OldHasOne',
+                        ],
+                    ],
+                ],
+                'ownerFixture' => 'legacy-relations',
+                'addColumns' => ['OldHasOneID' => DBInt::class],
+            ],
+            'polymorphic has_one' => [
+                'hasManyConfig' => [
+                    HasManyLinkOwner::class => [
+                        'PolyHasMany' => [
+                            'linkClass' => Link::class,
+                            'hasOne' => 'OldHasOne',
+                        ],
+                    ],
+                ],
+                'ownerFixture' => 'legacy-relations',
+                'addColumns' => [
+                    'OldHasOneID' => DBInt::class,
+                    'OldHasOneClass' => DBVarchar::class,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideMigrateHasManyRelations
+     */
+    public function testMigrateHasManyRelations(
+        array $hasManyConfig,
+        string $ownerFixture = null,
+        array $addColumns = [],
+        bool $relationStillExists = false
+    ): void {
+        LinkFieldMigrationTask::config()->set('has_many_links_data', $hasManyConfig);
+
+        if (!empty($addColumns) && !$ownerFixture) {
+            throw new LogicException('Test scenario is broken - need owner if we are adding columns.');
+        }
+
+        // Set up legacy has_one columns and data
+        if ($ownerFixture) {
+            $this->ensureColumnsExist($addColumns);
+            $baseTable = DataObject::getSchema()->baseDataTable(Link::class);
+            $db = DB::get_conn();
+            $ownerClass = array_key_first($hasManyConfig);
+            $owner = $this->objFromFixture($ownerClass, $ownerFixture);
+            foreach (array_keys($addColumns) as $columnName) {
+                $value = str_ends_with($columnName, 'ID') ? $owner->ID : $owner->ClassName;
+                SQLUpdate::create(
+                    $db->escapeIdentifier($baseTable),
+                    [$db->escapeIdentifier("{$baseTable}.{$columnName}") => $value]
+                )->execute();
+            }
+        }
+
+        if ($relationStillExists) {
+            $message = '';
+            foreach ($hasManyConfig as $ownerClass => $relationData) {
+                $owner = $this->objFromFixture($ownerClass, $ownerFixture);
+                foreach ($relationData as $hasManyRelation => $spec) {
+                    $linkClass = $spec['linkClass'];
+                    $hasOneRelation = $spec['hasOne'];
+                    $message .= "has_one relation '{$linkClass}.{$hasOneRelation} still exists. Cannot migrate has_many relation '{$ownerClass}.{$hasManyRelation}'.";
+                }
+            }
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage($message);
+        }
+
+        // Run the migration
+        $this->startCapturingOutput();
+        try {
+            $this->callPrivateMethod('migrateHasManyRelations');
+        } finally {
+            // If $relationStillExists is true, we will have an exception before this is run,
+            // but we still need to make sure we stop capturing output!
+            $output = $this->stopCapturingOutput();
+        }
+
+        if (empty($hasManyConfig)) {
+            $this->assertSame("No has_many relations to migrate.\n", $output);
+            return;
+        }
+
+        $expectedOutput = "Migrating has_many relations.\n";
+
+
+        if (!$relationStillExists) {
+            // Owner SHOULD have been set
+            foreach ($hasManyConfig as $ownerClass => $relationData) {
+                $owner = $this->objFromFixture($ownerClass, $ownerFixture);
+                foreach ($relationData as $hasManyRelation => $spec) {
+                    $list = $owner->$hasManyRelation();
+                    // Check that the Owner relation got set correctly for these
+                    $this->assertSame([$owner->ID], $list->columnUnique('OwnerID'));
+                    $this->assertSame([$hasManyRelation], $list->columnUnique('OwnerRelation'));
+                    $this->assertSame([$owner->ClassName], $list->columnUnique('OwnerClass'));
+                }
+            }
+        }
+
+        // Make sure we report about dropped columns
+        foreach (['', '_Versions', '_Live'] as $suffix) {
+            foreach (array_keys($addColumns) as $column) {
+                $expectedOutput .= "Dropping '{$baseTable}{$suffix}.{$column}' column.\n";
+            }
+        }
+
+        $this->assertSame($expectedOutput, $output);
+    }
+
+    public function providePublishLinks(): array
+    {
+        return [
+            'skip nothing' => [
+                'shouldPublishLink' => true,
+                'shouldPublishLinks' => true,
+            ],
+            'skip all links' => [
+                'shouldPublishLink' => true,
+                'shouldPublishLinks' => false,
+            ],
+            'skip individual links' => [
+                'shouldPublishLink' => false,
+                'shouldPublishLinks' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providePublishLinks
+     */
+    public function testPublishLinks(bool $shouldPublishLink, bool $shouldPublishLinks): void
+    {
+        // Get the live table before calling publishLinks
+        $liveTable = DataObject::getSchema()->tableName(Link::class) . '_Live';
+        $liveLinkContents = SQLSelect::create()
+            ->setFrom(Convert::symbol2sql($liveTable))
+            ->execute()
+            ->map();
+
+        OverrideMigrationStepsExtension::$shouldPublishLink = $shouldPublishLink;
+        OverrideMigrationStepsExtension::$shouldPublishLinks = $shouldPublishLinks;
+        $this->startCapturingOutput();
+        $this->callPrivateMethod('publishLinks');
+        $output = $this->stopCapturingOutput();
+
+        // Get the live table contents post-publish
+        $newLiveLinkContents = SQLSelect::create()
+            ->setFrom(Convert::symbol2sql($liveTable))
+            ->execute()
+            ->map();
+
+        // Output is based on whether we're skiping publishing for all links or not
+        if ($shouldPublishLinks) {
+            $this->assertSame("Publishing links.\nPublishing complete.\n", $output);
+        } else {
+            $this->assertSame("Skipping publish step.\n", $output);
+        }
+
+        // If we're publishing the links we should have different content in the live table
+        if ($shouldPublishLink && $shouldPublishLinks) {
+            $this->assertNotSame($liveLinkContents, $newLiveLinkContents);
+        } else {
+            $this->assertSame($liveLinkContents, $newLiveLinkContents);
+        }
+    }
+
+    /**
+     * Mostly this is just to validate that no errors get thrown if there's nothing to publish
+     */
+    public function testPublishLinksNoLinks(): void
+    {
+        Link::get()->removeAll();
+        // Get the live table before calling publishLinks
+        $liveTable = DataObject::getSchema()->tableName(Link::class) . '_Live';
+        $liveLinkContents = SQLSelect::create()
+            ->setFrom(Convert::symbol2sql($liveTable))
+            ->execute()
+            ->map();
+        // Call the method
+        $this->startCapturingOutput();
+        $this->callPrivateMethod('publishLinks');
+        // Check output
+        $this->assertSame(
+            "Publishing links.\nPublishing complete.\n",
+            $this->stopCapturingOutput()
+        );
+        // Check the live table didn't change
+        $newLiveLinkContents = SQLSelect::create()
+            ->setFrom(Convert::symbol2sql($liveTable))
+            ->execute()
+            ->map();
+        $this->assertSame($liveLinkContents, $newLiveLinkContents);
+    }
+
+    /**
+     * Test that nothing changes and correct text is output for publish step when links aren't versioned
+     */
+    public function testPublishLinksUnversioned(): void
+    {
+        // Get the live table before calling publishLinks
+        $liveTable = DataObject::getSchema()->tableName(Link::class) . '_Live';
+        $liveLinkContents = SQLSelect::create()
+            ->setFrom(Convert::symbol2sql($liveTable))
+            ->execute()
+            ->map();
+        // Remove versioning
+        Link::remove_extension(Versioned::class);
+        // Call the method
+        $this->startCapturingOutput();
+        $this->callPrivateMethod('publishLinks');
+        // Check output
+        $this->assertSame(
+            "Links are not versioned - skipping publish step due to project-level customisation.\n",
+            $this->stopCapturingOutput()
+        );
+        // Check the live table didn't change
+        $newLiveLinkContents = SQLSelect::create()
+            ->setFrom(Convert::symbol2sql($liveTable))
+            ->execute()
+            ->map();
+        $this->assertSame($liveLinkContents, $newLiveLinkContents);
+    }
+
+    public function provideCheckForBrokenLinks(): array
+    {
+        return [
+            'no broken links' => [
+                'hasBrokenLinks' => false,
+            ],
+            'with broken links' => [
+                'hasBrokenLinks' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideCheckForBrokenLinks
+     */
+    public function testCheckForBrokenLinks(bool $hasBrokenLinks): void
+    {
+        $brokenLinkFixtures = $this->getBrokenLinkFixtures($hasBrokenLinks);
+        $this->startCapturingOutput();
+        $this->callPrivateMethod('checkForBrokenLinks');
+        $output = $this->stopCapturingOutput();
+
+        $expectedOutputRegex = "Checking for broken links.\n";
+        if ($hasBrokenLinks) {
+            foreach (array_keys($brokenLinkFixtures) as $class) {
+                $safeClass = preg_quote($class);
+                $expectedOutputRegex .= "Found 2 broken links for the '$safeClass' class.\n";
+            }
+            $classNameLen = strlen(CustomLink::class);
+            $spaces = str_repeat(' ', $classNameLen - strlen('Link class'));
+            $hyphens = str_repeat('-', $classNameLen);
+            $expectedOutputRegex .= <<< CLI_TABLE
+            Broken links:
+            Link class$spaces | IDs of broken links
+            $hyphens | -------------------\n
+            CLI_TABLE;
+            foreach ($brokenLinkFixtures as $class => $ids) {
+                $paddedClass = str_pad($class, $classNameLen);
+                $safeClass = preg_quote($paddedClass);
+                // ID order isn't reliable, so we'll just check the format here and check the actual values separately.
+                $idsPlaceholder = str_repeat('\d+, ', count($ids) - 1) . '\d+';
+                $expectedOutputRegex .= "$safeClass | $idsPlaceholder\n";
+            }
+        } else {
+            foreach (array_keys($brokenLinkFixtures) as $class) {
+                $safeClass = preg_quote($class);
+                $expectedOutputRegex .= "Found 0 broken links for the '$safeClass' class.\n";
+            }
+            $expectedOutputRegex .= "No broken links.\n";
+        }
+        $this->assertMatchesRegularExpression('#' . $expectedOutputRegex . '#', $output);
+
+        // Check the IDs are correct (regardless of order)
+        if ($hasBrokenLinks) {
+            $output = preg_replace('/.*-------------------\n/s', '', $output);
+            $rows = explode("\n", $output);
+            foreach ($rows as $row) {
+                if (empty(trim($row))) {
+                    continue;
+                }
+                $parts = explode('|', $row);
+                if (count($parts) !== 2) {
+                    echo '';
+                }
+                $class = trim($parts[0]);
+                $ids = explode(', ', trim($parts[1]));
+                $toMatch = $brokenLinkFixtures[$class];
+                sort($ids);
+                sort($toMatch);
+                $this->assertEquals($toMatch, $ids);
+            }
+        }
+    }
+
+    /**
+     * @dataProvider provideCheckForBrokenLinks
+     */
+    public function testCheckForBrokenLinksWithHtmlOutput(bool $hasBrokenLinks): void
+    {
+        // Make sure we get HTML output
+        $reflectionCli = new ReflectionProperty(Environment::class, 'isCliOverride');
+        $reflectionCli->setAccessible(true);
+        $reflectionCli->setValue(false);
+        try {
+            $brokenLinkFixtures = $this->getBrokenLinkFixtures($hasBrokenLinks);
+            $this->startCapturingOutput();
+            $this->callPrivateMethod('checkForBrokenLinks');
+            $output = $this->stopCapturingOutput();
+
+            $expectedOutputRegex = '#Checking for broken links\.<br>';
+            if ($hasBrokenLinks) {
+                foreach (array_keys($brokenLinkFixtures) as $class) {
+                    $safeClass = preg_quote($class);
+                    $expectedOutputRegex .= "Found 2 broken links for the '$safeClass' class\.<br>";
+                }
+                $expectedOutputRegex .= 'Broken links:<br><table><thead><tr><th>Link class</th><th>IDs of broken links</th></tr></thead><tbody>';
+                foreach ($brokenLinkFixtures as $class => $ids) {
+                    $safeClass = preg_quote($class);
+                    // ID order isn't reliable, so we'll just check the format here and check the actual values separately.
+                    $idsPlaceholder = str_repeat('\d+, ', count($ids) - 1) . '\d+';
+                    $expectedOutputRegex .= "<tr><td>$safeClass</td><td>$idsPlaceholder</td></tr>";
+                }
+                $expectedOutputRegex .= '</tbody></table><br>#';
+            } else {
+                foreach (array_keys($brokenLinkFixtures) as $class) {
+                    $safeClass = preg_quote($class);
+                    $expectedOutputRegex .= "Found 0 broken links for the '$safeClass' class\.<br>";
+                }
+                $expectedOutputRegex .= 'No broken links\.<br>#';
+            }
+            $this->assertMatchesRegularExpression($expectedOutputRegex, $output);
+
+            // Check the IDs are correct (regardless of order)
+            if ($hasBrokenLinks) {
+                $crawler = new Crawler($output);
+                $tableRows = $crawler->filter('table tbody tr');
+                foreach ($tableRows as $row) {
+                    $class = trim($row->firstChild->textContent);
+                    $ids = explode(', ', trim($row->lastChild->textContent));
+                    $toMatch = $brokenLinkFixtures[$class];
+                    sort($ids);
+                    sort($toMatch);
+                    $this->assertEquals($toMatch, $ids);
+                }
+            }
+        } finally {
+            // Make sure we unset the CLI override
+            $reflectionCli->setValue(null);
+        }
+    }
+
+    private function getBrokenLinkFixtures(bool $hasBrokenLinks): array
+    {
+        $fixtures = [
+            EmailLink::class => [
+                $this->idFromFixture(EmailLink::class, 'broken-email-link01'),
+                $this->idFromFixture(EmailLink::class, 'broken-email-link02'),
+            ],
+            ExternalLink::class => [
+                $this->idFromFixture(ExternalLink::class, 'broken-external-link01'),
+                $this->idFromFixture(ExternalLink::class, 'broken-external-link02'),
+            ],
+            FileLink::class => [
+                $this->idFromFixture(FileLink::class, 'broken-file-link01'),
+                $this->idFromFixture(FileLink::class, 'broken-file-link02'),
+            ],
+            PhoneLink::class => [
+                $this->idFromFixture(PhoneLink::class, 'broken-phone-link01'),
+                $this->idFromFixture(PhoneLink::class, 'broken-phone-link02'),
+            ],
+            SiteTreeLink::class => [
+                $this->idFromFixture(SiteTreeLink::class, 'broken-sitetree-link01'),
+                $this->idFromFixture(SiteTreeLink::class, 'broken-sitetree-link02'),
+            ],
+            CustomLink::class => [
+                $this->idFromFixture(CustomLink::class, 'broken-custom-link01'),
+                $this->idFromFixture(CustomLink::class, 'broken-custom-link02'),
+            ],
+        ];
+        if (!$hasBrokenLinks) {
+            foreach ($fixtures as $class => $ids) {
+                $list = new DataList($class);
+                $list->byIDs($ids)->removeAll();
+            }
+        }
+        return $fixtures;
+    }
+
+    private function startCapturingOutput(): void
+    {
+        flush();
+        ob_start();
+    }
+
+    private function stopCapturingOutput(): string
+    {
+        return ob_get_clean();
+    }
+
+    private function callPrivateMethod(string $methodName, array $args = []): mixed
+    {
+        $task = Deprecation::withNoReplacement(fn() => new LinkFieldMigrationTask());
+        $reflectionMethod = new ReflectionMethod($task, $methodName);
+        $reflectionMethod->setAccessible(true);
+        return $reflectionMethod->invoke($task, ...$args);
+    }
+
+    private function ensureColumnsExist(array $columns, bool $includeVersioned = true)
+    {
+        $baseTable = DataObject::getSchema()->baseDataTable(Link::class);
+        $tables = [$baseTable];
+        if ($includeVersioned) {
+            $tables[] = "{$baseTable}_Versions";
+            $tables[] = "{$baseTable}_Live";
+        }
+        DB::get_schema()->schemaUpdate(function () use ($tables, $columns) {
+            foreach ($tables as $table) {
+                foreach ($columns as $column => $fieldType) {
+                    $dbField = DBField::create_field($fieldType, null, $column);
+                    $dbField->setTable($table);
+                    $dbField->requireField();
+                }
+            }
+        });
+    }
+}

--- a/tests/php/Tasks/LinkFieldMigrationTaskTest.yml
+++ b/tests/php/Tasks/LinkFieldMigrationTaskTest.yml
@@ -1,0 +1,156 @@
+SilverStripe\LinkField\Models\EmailLink:
+  broken-email-link01:
+    LinkText: 'Broken email link 01'
+    Email: null
+  broken-email-link02:
+    LinkText: 'Broken email link 02'
+    Email: ''
+  test-email-link01:
+    LinkText: 'test-email-link01'
+    Email: 'email@example.com'
+  test-email-link02:
+    LinkText: ''
+    Email: 'email2@example.com'
+  test-email-link03:
+    LinkText: null
+    Email: 'email3@example.com'
+
+SilverStripe\LinkField\Models\ExternalLink:
+  broken-external-link01:
+    LinkText: 'Broken external url link 01'
+    ExternalUrl: null
+  broken-external-link02:
+    LinkText: 'Broken external url link 02'
+    ExternalUrl: ''
+  test-external-link01:
+    LinkText: 'test-external-link01'
+    ExternalUrl: 'https://www.example.com/'
+  test-external-link02:
+    LinkText: ''
+    ExternalUrl: 'https://www.example.com/2'
+  test-external-link03:
+    LinkText: null
+    ExternalUrl: 'https://www.example.com/3'
+
+SilverStripe\LinkField\Models\FileLink:
+  broken-file-link01:
+    LinkText: 'Broken file link 01'
+    FileID: null
+  broken-file-link02:
+    LinkText: 'Broken file link 02'
+    FileID: 0
+  test-file-link01:
+    LinkText: 'test-file-link01'
+    # Doesn't matter if this is a real file or not for our purposes
+    FileID: 1
+  test-file-link02:
+    LinkText: ''
+    FileID: 2
+  test-file-link03:
+    LinkText: null
+    FileID: 3
+
+SilverStripe\LinkField\Models\PhoneLink:
+  broken-phone-link01:
+    LinkText: 'Broken phone link 01'
+    Phone: null
+  broken-phone-link02:
+    LinkText: 'Broken phone link 02'
+    Phone: ''
+  test-phone-link01:
+    LinkText: 'test-phone-link01'
+    Phone: '1'
+  test-phone-link02:
+    LinkText: ''
+    Phone: '2'
+  test-phone-link03:
+    LinkText: null
+    Phone: '3'
+
+SilverStripe\LinkField\Models\SiteTreeLink:
+  broken-sitetree-link01:
+    LinkText: 'Broken page link 01'
+    PageID: null
+  broken-sitetree-link02:
+    LinkText: 'Broken page link 02'
+    PageID: 0
+  test-sitetree-link01:
+    LinkText: 'test-sitetree-link01'
+    # Doesn't matter if this is a real page or not for our purposes
+    PageID: 1
+  test-sitetree-link02:
+    LinkText: ''
+    PageID: 2
+  test-sitetree-link03:
+    LinkText: null
+    PageID: 3
+
+SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\CustomLink:
+  broken-custom-link01:
+    LinkText: 'Broken custom link 01'
+    MyField: null
+  broken-custom-link02:
+    LinkText: 'Broken custom link 02'
+    MyField: 'broken'
+  test-custom-link01:
+    LinkText: 'test-custom-link01'
+    MyField: 'not broken1'
+  test-custom-link02:
+    LinkText: ''
+    MyField: 'not broken2'
+  test-custom-link03:
+    LinkText: null
+    MyField: 'not broken3'
+  test-custom-link04:
+    LinkText: 'link 4'
+    MyField: 'not broken4'
+  test-custom-link05:
+    LinkText: 'link 5'
+    MyField: 'not broken5'
+
+SilverStripe\LinkField\Tests\Models\LinkTest\LinkOwner:
+  owns-nothing:
+  owns-has-one:
+    Link: =>SilverStripe\LinkField\Models\EmailLink.test-email-link01
+  # This owns the same record that "owns-has-one" owns, so the Owner relation of the link will
+  # be set to "owns-has-one".
+  owns-has-one-again:
+    Link: =>SilverStripe\LinkField\Models\EmailLink.test-email-link01
+
+SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\MultiLinkOwner:
+  owns-one:
+    LinkOne: =>SilverStripe\LinkField\Models\EmailLink.test-email-link02
+  owns-another:
+    LinkTwo: =>SilverStripe\LinkField\Models\EmailLink.test-email-link03
+  owns-multiple:
+    LinkOne: =>SilverStripe\LinkField\Models\ExternalLink.test-external-link01
+    LinkTwo: =>SilverStripe\LinkField\Models\ExternalLink.test-external-link02
+
+SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\AmbiguousLinkOwner:
+  owns-one:
+    Link: =>SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\CustomLink.test-custom-link01
+
+SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\ReciprocalLinkOwner:
+  owns-many:
+    BaseLink: =>SilverStripe\LinkField\Models\ExternalLink.test-external-link03
+    CustomLink: =>SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\CustomLink.test-custom-link02
+    BelongsToLink: =>SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\CustomLink.test-custom-link03
+    HasManyLink: =>SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\CustomLink.test-custom-link04
+
+SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\PolymorphicLinkOwner:
+  owns-many:
+    PolymorphicLink: =>SilverStripe\LinkField\Models\FileLink.test-file-link01
+    PolymorphicReciprocalLink: =>SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\CustomLink.test-custom-link05
+    MultiRelationalLinkOne: =>SilverStripe\LinkField\Models\FileLink.test-file-link02
+    MultiRelationalLinkOneRelation: 'Owner'
+    MultiRelationalLinkTwo: =>SilverStripe\LinkField\Models\FileLink.test-file-link03
+    MultiRelationalLinkTwoRelation: 'SomethingElse'
+
+SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\HasManyLinkOwner:
+  # We can't add the relations here, because that would set them against a real has_one, but we want
+  # them to be added against columns that aren't added through the regular ORM to simulate legacy data
+  legacy-relations:
+  still-has-relation:
+    ForHasOne:
+      - =>SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\CustomLink.test-custom-link01
+      - =>SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest\CustomLink.test-custom-link02

--- a/tests/php/Tasks/LinkFieldMigrationTaskTest/AmbiguousLinkOwner.php
+++ b/tests/php/Tasks/LinkFieldMigrationTaskTest/AmbiguousLinkOwner.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class AmbiguousLinkOwner extends DataObject implements TestOnly
+{
+    private static string $table_name = 'LinkFieldTest_Tasks_AmbiguousLinkOwner';
+
+    private static array $has_one = [
+        'Link' => CustomLink::class,
+    ];
+}

--- a/tests/php/Tasks/LinkFieldMigrationTaskTest/CustomLink.php
+++ b/tests/php/Tasks/LinkFieldMigrationTaskTest/CustomLink.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\LinkField\Models\Link;
+
+class CustomLink extends Link implements TestOnly
+{
+    private static string $table_name = 'LinkFieldTest_Tasks_CustomLink';
+
+    private static array $db = [
+        'MyField' => 'Varchar',
+    ];
+
+    private static array $has_one = [
+        'ForHasMany' => HasManyLinkOwner::class,
+    ];
+
+    private static array $belongs_to = [
+        'ReciprocalLinkOwner' => ReciprocalLinkOwner::class . '.BelongsToLink',
+    ];
+
+    private static array $has_many = [
+        'AmbiguousOwner' => AmbiguousLinkOwner::class,
+        'ReciprocalLinkOwners' => ReciprocalLinkOwner::class . '.HasManyLink',
+        'PolymorphicLinkOwners' => PolymorphicLinkOwner::class . '.PolymorphicReciprocalLink',
+    ];
+}

--- a/tests/php/Tasks/LinkFieldMigrationTaskTest/CustomLinkMigrationExtension.php
+++ b/tests/php/Tasks/LinkFieldMigrationTaskTest/CustomLinkMigrationExtension.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+class CustomLinkMigrationExtension extends Extension implements TestOnly
+{
+    protected function updateCheckForBrokenLinks(array &$toCheck): void
+    {
+        $toCheck[CustomLink::class] = [
+            'field' => 'MyField',
+            'emptyValue' => [null, 'broken'],
+        ];
+    }
+}

--- a/tests/php/Tasks/LinkFieldMigrationTaskTest/HasManyLinkOwner.php
+++ b/tests/php/Tasks/LinkFieldMigrationTaskTest/HasManyLinkOwner.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\LinkField\Models\Link;
+use SilverStripe\ORM\DataObject;
+
+class HasManyLinkOwner extends DataObject implements TestOnly
+{
+    private static string $table_name = 'LinkFieldTest_Tasks_HasManyLinkOwner';
+
+    private static array $has_many = [
+        // Intentionally not using dot notation here.
+        'ForHasOne' => CustomLink::class,
+        'RegularHasMany' => Link::class,
+        'PolyHasMany' => Link::class,
+    ];
+}

--- a/tests/php/Tasks/LinkFieldMigrationTaskTest/MultiLinkOwner.php
+++ b/tests/php/Tasks/LinkFieldMigrationTaskTest/MultiLinkOwner.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest;
+
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\LinkField\Models\Link;
+use SilverStripe\ORM\DataObject;
+
+class MultiLinkOwner extends DataObject implements TestOnly
+{
+    private static string $table_name = 'LinkFieldTest_Tasks_MultiLinkOwner';
+
+    private static array $has_one = [
+        'LinkOne' => Link::class,
+        'LinkTwo' => Link::class,
+        'NotLink' => SiteTree::class,
+    ];
+}

--- a/tests/php/Tasks/LinkFieldMigrationTaskTest/OverrideMigrationStepsExtension.php
+++ b/tests/php/Tasks/LinkFieldMigrationTaskTest/OverrideMigrationStepsExtension.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\LinkField\Models\Link;
+
+class OverrideMigrationStepsExtension extends Extension implements TestOnly
+{
+    public static ?bool $shouldPublishLink = null;
+    public static ?bool $shouldPublishLinks = null;
+    public static ?bool $needsMigration = null;
+    public static array $shouldMigrateColumn = [];
+    public static array $shouldDropColumn = [];
+
+    protected function updateShouldPublishLink(Link $link, bool &$shouldPublishLink): void
+    {
+        if (self::$shouldPublishLink !== null) {
+            $shouldPublishLink = self::$shouldPublishLink;
+        }
+    }
+
+    protected function updateShouldPublishLinks(bool &$shouldPublishLinks): void
+    {
+        if (self::$shouldPublishLinks !== null) {
+            $shouldPublishLinks = self::$shouldPublishLinks;
+        }
+    }
+
+    protected function updateNeedsMigration(bool &$needsMigration): void
+    {
+        if (self::$needsMigration !== null) {
+            $needsMigration = self::$needsMigration;
+        }
+    }
+
+    protected function updateShouldMigrateColumn(string $table, string $column, bool &$shouldMigrateColumn): void
+    {
+        if (isset(self::$shouldMigrateColumn[$table])) {
+            $shouldMigrateColumn = self::$shouldMigrateColumn[$table];
+        }
+    }
+
+    protected function updateShouldDropColumn(string $table, string $column, bool &$shouldDropColumn): void
+    {
+        if (isset(self::$shouldDropColumn[$table])) {
+            $shouldDropColumn = self::$shouldDropColumn[$table];
+        }
+    }
+}

--- a/tests/php/Tasks/LinkFieldMigrationTaskTest/PolymorphicLinkOwner.php
+++ b/tests/php/Tasks/LinkFieldMigrationTaskTest/PolymorphicLinkOwner.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DataObjectSchema;
+
+class PolymorphicLinkOwner extends DataObject implements TestOnly
+{
+    private static string $table_name = 'LinkFieldTest_Tasks_PolymorphicLinkOwner';
+
+    private static array $has_one = [
+        'PolymorphicLink' => DataObject::class,
+        'PolymorphicReciprocalLink' => DataObject::class,
+        'MultiRelationalLinkOne' => [
+            'class' => DataObject::class,
+            DataObjectSchema::HAS_ONE_MULTI_RELATIONAL => true,
+        ],
+        'MultiRelationalLinkTwo' => [
+            'class' => DataObject::class,
+            DataObjectSchema::HAS_ONE_MULTI_RELATIONAL => true,
+        ],
+    ];
+}

--- a/tests/php/Tasks/LinkFieldMigrationTaskTest/ReciprocalLinkOwner.php
+++ b/tests/php/Tasks/LinkFieldMigrationTaskTest/ReciprocalLinkOwner.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverStripe\LinkField\Tests\Tasks\LinkFieldMigrationTaskTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\LinkField\Models\Link;
+use SilverStripe\ORM\DataObject;
+
+class ReciprocalLinkOwner extends DataObject implements TestOnly
+{
+    private static string $table_name = 'LinkFieldTest_Tasks_ReciprocalLinkOwner';
+
+    private static array $has_one = [
+        'BaseLink' => Link::class,
+        'CustomLink' => CustomLink::class,
+        'BelongsToLink' => CustomLink::class,
+        'HasManyLink' => CustomLink::class,
+    ];
+}


### PR DESCRIPTION

<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Provides a migration task and docs for upgrading from 2.x or 3.x to 4.x

## Dependencies
Requires https://github.com/silverstripe/silverstripe-framework/pull/11171 for one of the unit tests.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
1. Set up some links with v3 of the module
    - be as creative as you want with it, hopefully the guide tells you how to deal with your scenario.
    - Minimally have a `has_one` relation to `Link` and a `has_many` relation to `Link` using gridfield to manage the has_many.
1. Use the upgrade guide. Where it says to update to `^4` obviously you'll need to pull in this PR instead.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-linkfield/issues/228

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
