### PR TITLE
FIX Linkfield sorting issue

### DIFF
--- a/src/Models/Link.php
+++ b/src/Models/Link.php
@@ -191,7 +191,7 @@ class Link extends DataObject
         // Ensure a Sort value is set and that it's one larger than any other Sort value for
         // this owner relation so that newly created Links on MultiLinkField's are properly sorted
         if (!$this->Sort) {
-            $this->Sort = self::get()->filter([
+            $this->Sort = Link::get()->filter([
                 'OwnerID' => $this->OwnerID,
                 'OwnerRelation' => $this->OwnerRelation,
             ])->max('Sort') + 1;


### PR DESCRIPTION
## Description
The `self::get()` method returns list of specific Link types, because of this for each link type we reset and begin to increase `Sort` again.

## Parent issue
- https://github.com/silverstripe/silverstripe-linkfield/issues/258