### PR TITLE
DOC Document localising links

### DIFF
--- a/docs/en/02_configuration.md
+++ b/docs/en/02_configuration.md
@@ -129,3 +129,27 @@ class MyCustomLink extends Link
     // ...
 }
 ```
+
+## Localisation with `tractorcow/silverstripe-fluent` {#localisation}
+
+If you install the optional `tractorcow/silverstripe-fluent` module, you can localise your links by adding `FluentVersionedExtension` to the `Link` model. This works for all links, regardless of whether they're in a `has_one` or `has_many` relation.
+
+```yml
+SilverStripe\LinkField\Models\Link:
+  extensions:
+    - TractorCow\Fluent\Extension\FluentVersionedExtension
+```
+
+If you have chosen to remove the [`Versioned`](api:SilverStripe\Versioned\Versioned) extension from the `Link` model, apply `FluentExtension` instead:
+
+```yml
+SilverStripe\LinkField\Models\Link:
+  extensions:
+    - TractorCow\Fluent\Extension\FluentExtension
+```
+
+> [!NOTE]
+> Because `GridField` doesn't work in a react context, you won't have access to some UI functionality such as the "Localisation" tab.
+> The "Localisation" tab is referred to in fluent documentation as the "localisation manager".
+
+See the documentation in the [`tractorcow-farm/silverstripe-fluent` GitHub repository](https://github.com/tractorcow-farm/silverstripe-fluent) if you need to do anything more complex.


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Documents localising links with fluent.

Note that this won't work unless https://github.com/silverstripe/silverstripe-framework/pull/11195 is also merged. You can work around that by adding this configuration:

```yml
SilverStripe\LinkField\Models\Link:
  extensions:
    - TractorCow\Fluent\Extension\FluentVersionedExtension
  field_exclude:
    - OwnerRelation
```

## Original fluent spike
- https://github.com/silverstripe/silverstripe-linkfield/issues/210

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-linkfield/issues/237