### PR TITLE
MNT Update transifex config

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,14 +1,14 @@
 [main]
 host = https://www.transifex.com
 
-[silverstripe-link.master]
+[o:silverstripe:p:silverstripe-linkfield:r:master]
 file_filter = lang/<lang>.yml
 source_file = lang/en.yml
 source_lang = en
-type = YML
+type        = YML
 
-[silverstripe-link.master-js]
+[o:silverstripe:p:silverstripe-linkfield:r:master-js]
 file_filter = client/lang/src/<lang>.json
 source_file = client/lang/src/en.json
 source_lang = en
-type = KEYVALUEJSON
+type        = KEYVALUEJSON


### PR DESCRIPTION
Updates the transifex config to:
1. Use the correct reference (`silverstripe-linkfield`, not `silverstripe-link`)
2. Use the new format

## Issue
- https://github.com/silverstripe/.github/issues/234