### PR TITLE
DEP Bump minimum version of framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5.2",
+        "silverstripe/framework": "^5.3",
         "silverstripe/cms": "^5",
         "silverstripe/versioned": "^2",
         "silverstripe/admin": "^2.2"


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/284

Fixes --prefer-lowest build https://github.com/silverstripe/silverstripe-linkfield/actions/runs/9885486274/job/27303603941

1) SilverStripe\LinkField\Tests\Tasks\GorriecoeMigrationTaskTest::testGetNeedsMigration with data set "no old table" (false, false)
SilverStripe\ORM\Connect\DatabaseException: Couldn't run query:

INSERT INTO "GorriecoeMigrationTaskTest_OldLinkTable"
 ("Title", "Created", "LastEdited", "Type", "URL", "OpenInNewWindow", "MySort")
 VALUES
 (?, ?, ?, ?, ?, ?, ?)

Table 'ss_tmpdb_1720672189_8044314.GorriecoeMigrationTaskTest_OldLinkTable' doesn't exist

