### PR TITLE
MNT Resolve deprecation warning in test

### DIFF
--- a/tests/php/Tasks/LinkFieldMigrationTaskTest.php
+++ b/tests/php/Tasks/LinkFieldMigrationTaskTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\LinkField\Tests\Tasks;
 
 use LogicException;
+use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
 use RuntimeException;
@@ -1015,9 +1016,8 @@ class LinkFieldMigrationTaskTest extends SapphireTest
     public function testCheckForBrokenLinksWithHtmlOutput(bool $hasBrokenLinks): void
     {
         // Make sure we get HTML output
-        $reflectionCli = new ReflectionProperty(Environment::class, 'isCliOverride');
-        $reflectionCli->setAccessible(true);
-        $reflectionCli->setValue(false);
+        $reflectionCli = new ReflectionClass(Environment::class);
+        $reflectionCli->setStaticPropertyValue('isCliOverride', false);
         try {
             $brokenLinkFixtures = $this->getBrokenLinkFixtures($hasBrokenLinks);
             $this->startCapturingOutput();
@@ -1062,7 +1062,7 @@ class LinkFieldMigrationTaskTest extends SapphireTest
             }
         } finally {
             // Make sure we unset the CLI override
-            $reflectionCli->setValue(null);
+            $reflectionCli->setStaticPropertyValue('isCliOverride', null);
         }
     }
 


### PR DESCRIPTION
See https://www.php.net/manual/en/migration83.deprecated.php about the deprecation
See https://www.php.net/manual/en/reflectionproperty.setvalue.php for the suggested solution

Not targeting `4.0` because this code doesn't exist on that branch.

## Issues
- https://github.com/silverstripe/.github/issues/309