### PR TITLE
DEP Bump framework dependency 'cause we're using new API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5.3",
+        "silverstripe/framework": "^5.4",
         "silverstripe/cms": "^5",
         "silverstripe/versioned": "^2",
         "silverstripe/admin": "^2.2"


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-linkfield/actions/runs/11026310005/job/30622641392

> Call to undefined method SilverStripe\Dev\Deprecation::withSuppressedNotice()

## Issue
- https://github.com/silverstripe/.github/issues/313