### PR TITLE
FIX FileLink does not own the File

### DIFF
--- a/src/Models/FileLink.php
+++ b/src/Models/FileLink.php
@@ -21,6 +21,10 @@ class FileLink extends Link
         'File' => File::class,
     ];
 
+    private static $owns = [
+        'File',
+    ];
+
     private static int $menu_priority = 10;
 
     private static $icon = 'font-icon-image';


### PR DESCRIPTION
## Description
The FileLink link type does not own it's file so when the link is published either through a recursive publish or directly the file itself is left in draft.

## Manual testing steps
1. Have a Link as either a has_one or has_many relationship on an object that owns the link relationship.
2. Then add a file link to a newly uploaded file which will be then in draft only. If the object with the link relationship is versioned publish the object if not save.
3. Verify the file is now published

## Issues
- #340

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
