### PR TITLE
ENH Use config instead of runtime code to remove menu item

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,6 +1,0 @@
-<?php
-
-use SilverStripe\Admin\CMSMenu;
-use SilverStripe\LinkField\Controllers\LinkFieldController;
-
-CMSMenu::remove_menu_class(LinkFieldController::class);

--- a/src/Controllers/LinkFieldController.php
+++ b/src/Controllers/LinkFieldController.php
@@ -31,6 +31,8 @@ class LinkFieldController extends LeftAndMain
 
     private static string $url_segment = 'linkfield';
 
+    private static $ignore_menuitem = true;
+
     private static array $url_handlers = [
         'linkForm/$ItemID' => 'linkForm',
         'GET data/$ItemID' => 'linkData',


### PR DESCRIPTION
Quick tidyup to use the `ignore_menuitem` configuration property instead of removing the menu item at runtime.

Can't refactor to use `AdminController` instead of `LeftAndMain` yet because it needs formschema - but this small refactor will make that slightly easier when I come to it.

## Issue
- https://github.com/silverstripe/silverstripe-admin/issues/1761