### PR TITLE
MNT Use caret for elemental dev requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "silverstripe/frameworktest": "^2",
-        "dnadesign/silverstripe-elemental": "6.x-dev",
+        "dnadesign/silverstripe-elemental": "^6",
         "silverstripe/recipe-testing": "^4",
         "silverstripe/standards": "^1",
         "silverstripe/documentation-lint": "^1",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/357

I *think* this might be preventing [linkfield merge-up workflow from working](https://github.com/silverstripe/silverstripe-linkfield/actions/runs/12761123801/job/35567645917), though maybe not.

Either way, it should be a caret requirement like it is in CMS 5