### PR TITLE
MNT Fix link test to not pre-cache link owner before test starts.

### DIFF
--- a/tests/php/Controllers/LinkFieldControllerTest.php
+++ b/tests/php/Controllers/LinkFieldControllerTest.php
@@ -13,6 +13,7 @@ use SilverStripe\LinkField\Tests\Models\LinkTest\LinkOwner;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\LinkField\Models\Link;
 use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\ORM\DataList;
 
 class LinkFieldControllerTest extends FunctionalTest
 {
@@ -50,6 +51,8 @@ class LinkFieldControllerTest extends FunctionalTest
         $link = $this->getFixtureLink();
         $owner = $this->getFixtureLinkOwner();
         $owner->Link = $link;
+        $owner->write();
+        DataList::reset(LinkOwner::class);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
With the new caching, this will fail tests that add versioned to the class. That's because of a combination of factors:

- extension instances are stored on instances instead of accessed statically (see https://github.com/silverstripe/silverstripe-framework/issues/11772) which means a record cached _before versioned is applied_ doesn't have a versioned extension instance
- in `DataObject::get_one()`, the `getUniqueKeyComponents()` method is used to determine the cache key, which just _happens_ to be called on a singleton, and we just _happen_ to have not generated a singleton of the class until now, which means it has the versioned extension freshly added to it and that is counted in the cache key where before that part of the cache key was empty (and therefore the key doesn't match the original unversioned record's cache key with `get_one`)
- In `DataList` when caching is enabled, `getUniqueKeyComponents()` isn't taken into account - instead the resulting SQL is used. This includes versioning (see new tests in https://github.com/silverstripe/silverstripe-versioned/pull/517) but the versioned state is draft which uses the base table, so the SQL matches the original query and returns the originally cached record (which is correct behaviour).

This would be extremely unlikely to occur in non-test code, and I think our response to a bug report would be "reset your cache after applying the extension, or just don't fiddle around with extensions at runtime except inside `_config.php`".

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767