### PR TITLE
DEP Require framework ^6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/cms": "^6",
         "silverstripe/versioned": "^3"
     },


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/433

Fixes the prefer lowest build
`Error: Call to undefined method SilverStripe\ORM\DataList::reset()`
https://github.com/silverstripe/silverstripe-linkfield/actions/runs/16613554079/job/47001520014