### PR TITLE
ENH Disable sorting on queries where sort order doesn't matter

### DIFF
--- a/src/Form/MultiLinkField.php
+++ b/src/Form/MultiLinkField.php
@@ -138,7 +138,7 @@ class MultiLinkField extends AbstractLinkField
         }
 
         // Load ids from relation
-        $value = array_values($relation->getIDList() ?? []);
+        $value = $relation->column('ID');
         parent::setValue($value);
     }
 

--- a/src/Tasks/MigrationTaskTrait.php
+++ b/src/Tasks/MigrationTaskTrait.php
@@ -388,7 +388,7 @@ trait MigrationTaskTrait
             foreach ($checkForBrokenLinks as $class => $data) {
                 $field = $data['field'];
                 $emptyValue = $data['emptyValue'];
-                $ids = DataObject::get($class)->filter([$field => $emptyValue])->column('ID');
+                $ids = DataObject::get($class)->filter([$field => $emptyValue])->sort(null)->column('ID');
                 $numBroken = count($ids);
                 $this->output->writeln("Found $numBroken broken links for the '$class' class.");
                 if ($numBroken > 0) {

--- a/tests/behat/features/create-edit-linkfield.feature
+++ b/tests/behat/features/create-edit-linkfield.feature
@@ -181,6 +181,11 @@ I want to add links to pages, files, external URLs, email addresses and phone nu
     Then I should not see "Email link" in the "[data-field-id='Form_EditForm_HasOneLink']" element
     Then I press the "Publish" button
 
+    # Test that order is retained after refreshing
+    When I reload the page
+    Then I should see "All about us" in the "[data-field-id='Form_EditForm_HasManyLinks'] .link-picker__link--is-last" element
+    And I should see "External URL" in the "[data-field-id='Form_EditForm_HasManyLinks'] .link-picker__link--is-first" element
+
   Scenario: Create file link with nested redux form
     When I click on the "[data-field-id='Form_EditForm_HasManyLinks'] button" element
     Then I should see "Link to a file" in the "[data-field-id='Form_EditForm_HasManyLinks'] .dropdown-item:nth-of-type(2)" element


### PR DESCRIPTION
Sorting queries can be slow, especially on large datasets and especially if indexes aren't optimised. We should avoid sorting when the sort order doesn't matter.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11833