### PR TITLE
ENH Hide font icons from screen readers

### DIFF
--- a/templates/SilverStripe/LinkField/Form/LinkField.ss
+++ b/templates/SilverStripe/LinkField/Form/LinkField.ss
@@ -7,7 +7,9 @@
     <% include SilverStripe/LinkField/Form/LinkField_Spinner  %>
     <div>
         <div class="link-picker__link link-picker__link--is-first link-picker__link--is-last form-control link-picker__link--disabled link-picker__link--published" role="button" aria-disabled="false" aria-roledescription="sortable" aria-describedby="" id="link-picker__link-42">
-            <button type="button" disabled="" class="link-picker__button font-icon-link btn btn-secondary disabled"></button>
+            <button type="button" disabled="" class="link-picker__button btn btn-secondary disabled">
+                <span class="font-icon-link" aria-hidden="true"></span>
+            </button>
         </div>
     </div>
   </div>

--- a/templates/SilverStripe/LinkField/Form/MultiLinkField.ss
+++ b/templates/SilverStripe/LinkField/Form/MultiLinkField.ss
@@ -12,8 +12,9 @@
           type="button"
           aria-haspopup="true"
           aria-expanded="false"
-          class="link-picker__menu-toggle font-icon-plus-1 dropdown-toggle btn btn-secondary"
+          class="link-picker__menu-toggle dropdown-toggle btn btn-secondary"
           aria-label="<%t SilverStripe\LinkField\Models\MultiLinkField.AddLink "Add link" %>">
+            <span class="font-icon-plus-1" aria-hidden="true"></span>
             <%t SilverStripe\LinkField\Models\MultiLinkField.AddLink "Add link" %>
         </button>
       </div>
@@ -24,8 +25,11 @@
         <button
           type="button"
           disabled=""
-          class="link-picker__button font-icon-link btn btn-secondary disabled"
-          aria-label="<%t SilverStripe\LinkField\Models\MultiLinkField.EditLink "Edit link" %>"></button>
+          class="link-picker__button btn btn-secondary disabled"
+          aria-label="<%t SilverStripe\LinkField\Models\MultiLinkField.EditLink "Edit link" %>"
+        >
+          <span class="font-icon-link" aria-hidden="true"></span>
+        </button>
       </div>
       <% end_loop %>
     </div>


### PR DESCRIPTION
- Hides decorative icons from screen readers (usually by adding an inner `span`)

I didn't notice any visual difference without the admin PR so we don't need to bump the constraint.

## Issue

- https://github.com/silverstripe/silverstripe-admin/issues/1957