### PR TITLE
DEP Require elemental ^6.2 as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "silverstripe/frameworktest": "^2",
-        "dnadesign/silverstripe-elemental": "^6",
+        "dnadesign/silverstripe-elemental": "^6.2",
         "silverstripe/recipe-testing": "^4",
         "silverstripe/standards": "^1",
         "silverstripe/documentation-lint": "^1",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/457

Fixes https://github.com/silverstripe/silverstripe-linkfield/actions/runs/18360914030/job/52304196565#step:12:436

Behat test is looking for "Add new block", but the button is still "Add block"

Happened because of this PR https://github.com/silverstripe/silverstripe-elemental/pull/1375