### PR TITLE
MNT Update unit tests for PHP 8.5

### DIFF
--- a/tests/php/Controllers/LinkFieldControllerTest.php
+++ b/tests/php/Controllers/LinkFieldControllerTest.php
@@ -190,7 +190,6 @@ class LinkFieldControllerTest extends FunctionalTest
         $request->setSession(new Session([]));
         $controller = new LinkFieldController();
         $reflectionFindAction = new ReflectionMethod($controller, 'findAction');
-        $reflectionFindAction->setAccessible(true);
         $reflectionFindAction->invoke($controller, $request);
         $controller->setRequest($request);
         $form = $controller->linkForm();

--- a/tests/php/Form/AbstractLinkFieldTest.php
+++ b/tests/php/Form/AbstractLinkFieldTest.php
@@ -33,7 +33,6 @@ class AbstractLinkFieldTest extends SapphireTest
         $form->loadDataFrom($block);
         $reflector = new ReflectionObject($field);
         $method = $reflector->getMethod('getOwnerFields');
-        $method->setAccessible(true);
         $res = $method->invoke($field);
         $this->assertEquals([
             'ID' => $block->ID,

--- a/tests/php/Form/MultiLinkFieldTest.php
+++ b/tests/php/Form/MultiLinkFieldTest.php
@@ -67,7 +67,6 @@ class MultiLinkFieldTest extends SapphireTest
     {
         $field = new MultiLinkField('');
         $reflectionMethod = new ReflectionMethod($field, 'convertValueToArray');
-        $reflectionMethod->setAccessible(true);
         $this->assertSame($expected, $reflectionMethod->invoke($field, $value));
     }
 

--- a/tests/php/Models/FileLinkTest.php
+++ b/tests/php/Models/FileLinkTest.php
@@ -40,8 +40,6 @@ class FileLinkTest extends SapphireTest
     public function testGetDefaultTitle(): void
     {
         $reflectionGetDefaultTitle = new ReflectionMethod(FileLink::class, 'getDefaultTitle');
-        $reflectionGetDefaultTitle->setAccessible(true);
-
         // File does not exist
         $link = new FileLink();
         $this->assertSame('(File missing)', $reflectionGetDefaultTitle->invoke($link));

--- a/tests/php/Models/SiteTreeLinkTest.php
+++ b/tests/php/Models/SiteTreeLinkTest.php
@@ -37,8 +37,6 @@ class SiteTreeLinkTest extends SapphireTest
     public function testGetDefaultTitle(): void
     {
         $reflectionGetDefaultTitle = new ReflectionMethod(SiteTreeLink::class, 'getDefaultTitle');
-        $reflectionGetDefaultTitle->setAccessible(true);
-
         // Page does not exist
         $link = new SiteTreeLink();
         $this->assertSame('(Page missing)', $reflectionGetDefaultTitle->invoke($link));

--- a/tests/php/Tasks/GorriecoeMigrationTaskTest.php
+++ b/tests/php/Tasks/GorriecoeMigrationTaskTest.php
@@ -675,18 +675,15 @@ class GorriecoeMigrationTaskTest extends SapphireTest
         $task = new GorriecoeMigrationTask();
         $output = new PolyOutput(PolyOutput::FORMAT_ANSI, wrappedOutput: $this->buffer);
         $reflectionProperty = new ReflectionProperty($task, 'output');
-        $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($task, $output);
 
         // getNeedsMigration() sets the table to pull from.
         // If we're not testing that method, we need to set the table ourselves.
         if ($this->name() !== 'testGetNeedsMigration') {
             $reflectionProperty = new ReflectionProperty($task, 'oldTableName');
-            $reflectionProperty->setAccessible(true);
             $reflectionProperty->setValue($task, self::OLD_LINK_TABLE);
         }
         $reflectionMethod = new ReflectionMethod($task, $methodName);
-        $reflectionMethod->setAccessible(true);
         return $reflectionMethod->invoke($task, ...$args);
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.