### PR TITLE
Add missing Slovenian translation for link management

### DIFF
--- a/client/lang/sl.js
+++ b/client/lang/sl.js
@@ -7,6 +7,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
 } else {
   ss.i18n.addDictionary('sl', {
     "LinkField.ADD_LINK": "Dodaj povezavo",
+    "LinkField.ADD_NEW_LINK": "Dodaj novo povezavo",
     "LinkField.ARCHIVE": "Arhiviraj",
     "LinkField.ARCHIVE_CONFIRM": "Želite arhivirati to povezavo?",
     "LinkField.ARCHIVE_ERROR": "Napaka pri arhiviranju povezave",
@@ -17,6 +18,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "LinkField.DELETE_ERROR": "Napaka pri brisanju povezave",
     "LinkField.DELETE_SUCCESS": "Povezava je izbrisana",
     "LinkField.EDIT_LINK": "Uredi povezavo",
+    "LinkField.EXCEEDS_MAXIMUM_LINKS": "Dosegli ste največje dovoljeno število povezav, ki jih lahko dodate.",
     "LinkField.FAILED_TO_LOAD_LINKS": "Napaka pri nalaganju povezav(e)",
     "LinkField.FAILED_TO_SAVE_LINK": "Napaka pri shranjevanju povezave",
     "LinkField.LINK_DRAFT_LABEL": "Osnutek",


### PR DESCRIPTION
Added missing Slovenian translations for linkfield:

LinkField.ADD_NEW_LINK
LinkField.EXCEEDS_MAXIMUM_LINKS

<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- # https://github.com/silverstripe/silverstripe-linkfield/issues/449

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [ ] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
